### PR TITLE
Update support for medicalvolume with dosma==0.0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     
             -   name: Install Dependencies
                 run: |
-                    pip install -e ".[dev, text, vision, tabular, embeddings-linux]"
+                    pip install -e ".[dev, text, vision, tabular, embeddings-linux, medimg]"
                     
             -   name: Test with pytest
                 run: |

--- a/mosaic/cells/volume.py
+++ b/mosaic/cells/volume.py
@@ -61,10 +61,10 @@ class MedicalVolumeCell(PathsMixin, AbstractCell):
         return image[index]
 
     def __str__(self):
-        return f"{self.__class__.__name__}({self.name})"
+        return f"{self.__class__.__name__}({self.paths})"
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.name})"
+        return f"{self.__class__.__name__}({self.paths})"
 
     @classmethod
     def _unroll_path(cls, paths: Sequence[Path]):

--- a/mosaic/cells/volume.py
+++ b/mosaic/cells/volume.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Callable, Dict, Sequence, Union
 
@@ -9,7 +8,7 @@ try:
     from dosma.core.io.format_io import DataReader
 
     _dosma_available = True
-except ImportError as e:
+except ImportError:
     _dosma_available = False
 
 import pydicom
@@ -50,8 +49,8 @@ class MedicalVolumeCell(PathsMixin, AbstractCell):
         super(MedicalVolumeCell, self).__init__(paths=paths, *args, **kwargs)
         if not _dosma_available:  # pragma: no-cover
             raise ImportError(
-                "You want to use `dosma` for medical image I/O which is not installed yet,"
-                " install it with `pip install dosma`."
+                "You want to use `dosma` for medical image I/O which is not"
+                "installed yet, install it with `pip install dosma`."
             )
         self._metadata = None
         self.transform: Callable = transform

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ EXTRAS = {
         "wilds>=1.1.0",
     ],
     "medimg": [
-        "dosma>=0.0.12",
+        "dosma>=0.0.13",
     ],
 }
 

--- a/tests/mosaic/cells/test_volume.py
+++ b/tests/mosaic/cells/test_volume.py
@@ -1,0 +1,72 @@
+import unittest
+
+import numpy as np
+import torch
+from dosma.core.io.dicom_io import DicomReader
+from pydicom.data import get_testdata_file
+
+from mosaic.cells.volume import MedicalVolumeCell
+
+
+class TestMedicalVolumeCell(unittest.TestCase):
+    """Test the MedicalVolumeCell with sample slice data from pydicom."""
+
+    # A slice of a CT - provided by pydicom
+    _ct_file = get_testdata_file("CT_small.dcm")
+
+    def test_basic_construction(self):
+        cell = MedicalVolumeCell(self._ct_file, loader=DicomReader(group_by=None))
+        assert isinstance(cell.loader, DicomReader)
+
+        cell = MedicalVolumeCell(self._ct_file, loader=DicomReader(group_by=None))
+        assert cell.transform is None
+        assert isinstance(cell.loader, DicomReader)
+
+    def test_transform(self):
+        cell = MedicalVolumeCell(
+            self._ct_file,
+            loader=DicomReader(group_by=None),
+            transform=lambda x: torch.from_numpy(np.asarray(x)),
+        )
+        out = cell.get()
+        assert isinstance(out, torch.Tensor)
+
+    def test_metadata(self):
+        cell = MedicalVolumeCell(
+            self._ct_file,
+            loader=DicomReader(group_by=None),
+        )
+        _ = cell.get()
+        assert cell._metadata is not None
+        metadata = cell._metadata
+
+        # Fetching the cell again should not update the underlying metadata.
+        _ = cell.get()
+        assert id(cell._metadata) == id(metadata)
+
+        metadata = cell.get_metadata(ignore_bytes=True, readable=True, as_raw_type=True)
+        assert all(not isinstance(v, bytes) for v in metadata.values())
+        assert all(isinstance(k, str) for k in metadata)
+        raw_types = (str, int, float, list, tuple)
+        assert all(isinstance(v, raw_types) for v in metadata.values()), "\n".join(
+            [
+                f"{k} ({type(v)}): {v}"
+                for k, v in metadata.items()
+                if not isinstance(v, raw_types)
+            ]
+        )
+
+    def test_state(self):
+        dr = DicomReader(group_by=None)
+        cell = MedicalVolumeCell(
+            self._ct_file,
+            loader=dr,
+            transform=lambda x: torch.from_numpy(np.asarray(x)),
+        )
+        state = cell.get_state()
+
+        cell2 = MedicalVolumeCell.from_state(state)
+
+        assert cell.paths == cell2.paths
+        assert isinstance(cell2.loader, DicomReader) and (cell2.loader.group_by is None)
+        assert torch.all(cell.get() == cell2.get())


### PR DESCRIPTION
Add support for `dosma.MedicalVolume` using the `MedicalVolumeCell`. This object is a lazy loader for medical images:
- loading is done with built-in data loaders
- key metadata information can be rolled out of the the medical image and accessed with `get_metadata()`
- `get()` returns a MedicalVolume when no transforms are specified