### PR TITLE
Add lazy indexing functionality, e.g. `dp.lz[0:3]`

### DIFF
--- a/mosaic/columns/cell_column.py
+++ b/mosaic/columns/cell_column.py
@@ -16,27 +16,30 @@ class CellColumn(AbstractColumn):
     def __init__(
         self,
         cells: Sequence[AbstractCell] = None,
-        materialize: bool = True,
         *args,
         **kwargs,
     ):
         super(CellColumn, self).__init__(
             data=cells,
-            materialize=materialize,
             *args,
             **kwargs,
         )
 
-    def _get_batch(self, indices: np.ndarray):
-        if self.materialize:
+    def _get_cell(self, index: int, materialize: bool = True):
+        cell = self._data[index]
+        if materialize:
+            return cell.get()
+        else:
+            return cell
+
+    def _get_batch(self, indices: np.ndarray, materialize: bool = True):
+        if materialize:
             # if materializing, return a batch (by default, a list of objects returned
             # by `.get`, otherwise the batch format specified by `self.collate`)
             return self.collate([self._data[i].get() for i in indices])
 
         else:
-            return self.__class__(
-                [self._data[i] for i in indices], materialize=self.materialize
-            )
+            return self.__class__([self._data[i] for i in indices])
 
     @classmethod
     def from_cells(cls, cells: Sequence[AbstractCell], *args, **kwargs):

--- a/mosaic/columns/image_column.py
+++ b/mosaic/columns/image_column.py
@@ -10,13 +10,15 @@ logger = logging.getLogger(__name__)
 
 
 class ImageColumn(CellColumn):
+    def __init__(self, *args, **kwargs):
+        super(ImageColumn, self).__init__(*args, **kwargs)
+
     @classmethod
     def from_filepaths(
         cls,
         filepaths: Sequence[str] = None,
         loader: callable = None,
         transform: callable = None,
-        materialize: bool = True,
         *args,
         **kwargs,
     ):
@@ -24,7 +26,6 @@ class ImageColumn(CellColumn):
 
         return cls(
             cells=cells,
-            materialize=materialize,
             *args,
             **kwargs,
         )

--- a/mosaic/columns/numpy_column.py
+++ b/mosaic/columns/numpy_column.py
@@ -112,10 +112,10 @@ class NumpyArrayColumn(
         # don't remap index since we take care of visibility with self.data
         return index
 
-    def _get_cell(self, index: int):
+    def _get_cell(self, index: int, materialize: bool = True):
         return self.data[index]
 
-    def _get_batch(self, indices):
+    def _get_batch(self, indices, materialize: bool = True):
         return self.data[indices]
 
     @classmethod

--- a/mosaic/columns/tensor_column.py
+++ b/mosaic/columns/tensor_column.py
@@ -89,10 +89,10 @@ class TensorColumn(
         # don't remap index since we take care of visibility with self.data
         return index
 
-    def _get_cell(self, index: int):
+    def _get_cell(self, index: int, materialize: bool = True):
         return self.data[index]
 
-    def _get_batch(self, indices):
+    def _get_batch(self, indices, materialize: bool = True):
         return self.data[indices]
 
     @classmethod

--- a/mosaic/mixins/materialize.py
+++ b/mosaic/mixins/materialize.py
@@ -6,5 +6,13 @@ class MaterializationMixin:
         self._materialize = materialize
 
     @property
-    def materialize(self):
-        return self._materialize
+    def lz(self):
+        return _LazyIndexer(self)
+
+
+class _LazyIndexer:
+    def __init__(self, obj: object):
+        self.obj = obj
+
+    def __getitem__(self, index):
+        return self.obj._get(index, materialize=False)

--- a/mosaic/mixins/visibility.py
+++ b/mosaic/mixins/visibility.py
@@ -18,18 +18,23 @@ class VisibilityMixin:
     @visible_rows.setter
     def visible_rows(self, indices: Optional[Sequence]):
         """Set the visible rows of the object."""
-        if indices is None:
-            self._visible_rows = None
-        else:
-            if len(indices):
-                assert min(indices) >= 0 and max(indices) < len(self), (
-                    f"Ensure min index {min(indices)} >= 0 and "
-                    f"max index {max(indices)} < {len(self)}."
-                )
-            if self._visible_rows is not None:
-                self._visible_rows = self._visible_rows[np.array(indices, dtype=int)]
+        if indices is not None and len(indices):
+            assert min(indices) >= 0 and max(indices) < len(self), (
+                f"Ensure min index {min(indices)} >= 0 and"
+                f" max index {max(indices)} < {len(self)}."
+            )
+
+        if self._visible_rows is None:
+            if indices is None:
+                self._visible_rows = None
             else:
                 self._visible_rows = np.array(indices, dtype=int)
+        else:
+            if indices is None:
+                # do nothing – keep old visible_roows
+                pass
+            else:
+                self._visible_rows = self._visible_rows[np.array(indices, dtype=int)]
 
         # Identify that `self` corresponds to a DataPanel
         if hasattr(self, "_data") and isinstance(self._data, Mapping):

--- a/tests/testbeds.py
+++ b/tests/testbeds.py
@@ -1,6 +1,11 @@
 """A collection of simple testbeds to build test cases."""
+import os
 from copy import deepcopy
 
+import numpy as np
+from PIL import Image
+
+from mosaic.columns.image_column import ImageColumn
 from mosaic.datapanel import DataPanel
 from mosaic.tools.identifier import Identifier
 
@@ -89,38 +94,57 @@ class MockTestBedv1:
         assert len(self.dataset) == 4
 
 
-# class MockVisionTestBed:
-#     def __init__(self, wrap_dataset: bool = False):
-#         """[summary]
-#
-#         Args:
-#             wrap_dataset (bool, optional): If `True`, create a
-#             `mosaic.DataPanel`
-#             ,
-#                 otherwise create a
-#                 `mosaic.core.dataformats.vision.VisionDataPane`
-#                 Defaults to False.
-#         """
-#         cache_dir = os.path.join(tempfile.gettempdir(), "RGVisionTests")
-#         if not os.path.exists(cache_dir):
-#             os.makedirs(cache_dir)
-#         self.image_paths = []
-#         self.image_tensors = []
-#         self.images = []
-#
-#         for i in range(200, 231, 10):
-#             self.image_paths.append(os.path.join(cache_dir, "{}.png".format(i)))
-#             self.image_tensors.append(i * torch.ones((10, 10, 3)))
-#             save_image(self.image_tensors[-1], self.image_paths[-1])
-#             self.images.append(RGImage(self.image_paths[-1]))
-#
-#         self.batch = {
-#             "a": [{"e": 1}, {"e": 2}, {"e": 3}, {"e": 4}],
-#             "b": ["u", "v", "w", "x"],
-#             "i": self.image_paths,
-#         }
-#
-#         if wrap_dataset:
-#             self.dataset = DataPanel.load_image_dataset(self.batch, img_columns="i")
-#         else:
-#             self.dataset = VisionDataPane(self.batch, img_columns="i")
+class MockDatapanel:
+    def __init__(
+        self,
+        length: int,
+        use_visible_rows: bool = False,
+        use_visible_columns: bool = False,
+        include_image_column: bool = False,
+        tmpdir: str = None,
+    ):
+        batch = {
+            "a": np.arange(length),
+            "b": list(np.arange(length)),
+            "c": [{"a": 2}] * length,
+        }
+
+        if include_image_column:
+            assert tmpdir is not None
+            self.img_col = MockImageColumn(length=length, tmpdir=tmpdir)
+            batch["img"] = self.img_col.col
+
+        self.dp = DataPanel.from_batch(batch)
+
+        self.visible_rows = [0, 4, 6, 11] if use_visible_rows else None
+        if use_visible_rows:
+            self.dp.visible_rows = self.visible_rows
+
+        self.visible_columns = ["a", "b"] if use_visible_columns else None
+        if use_visible_columns:
+            self.dp.visible_columns = self.visible_columns
+
+
+class MockImageColumn:
+    def __init__(self, length: int, tmpdir: str):
+        """[summary]
+
+        Args:
+            wrap_dataset (bool, optional): If `True`, create a
+            `mosaic.DataPanel`
+            ,
+                otherwise create a
+                `mosaic.core.dataformats.vision.VisionDataPane`
+                Defaults to False.
+        """
+        self.image_paths = []
+        self.image_arrays = []
+        self.images = []
+
+        for i in range(1, length + 1):
+            self.image_paths.append(os.path.join(tmpdir, "{}.png".format(i)))
+            self.image_arrays.append((i * np.ones((10, 10, 3))).astype(np.uint8))
+            im = Image.fromarray(self.image_arrays[-1])
+            im.save(self.image_paths[-1])
+
+        self.col = ImageColumn.from_filepaths(self.image_paths)


### PR DESCRIPTION
`Column` and `Datapanel` no longer maintain state specifying whether cells should be materialized on `__getitem__` (_i.e._ `self._materialize` property no longer exists). Instead, if a user would like to index without materializing, they can use the `lz` indexer like: `dp.lz[0:3]`. 

Other changes:
- Added tests for lz indexer
- Moved logic for `__getitem__` into a method called `_get` which accepts a `materialize` argument. 