### PR TITLE
Add support for lazy `map`, `update` and `filter` through `materialize` arg

### DIFF
--- a/mosaic/mixins/inspect_fn.py
+++ b/mosaic/mixins/inspect_fn.py
@@ -16,6 +16,7 @@ class FunctionInspectorMixin:
         batched: bool = False,
         data=None,
         indices=None,
+        materialize=True,
     ) -> SimpleNamespace:
 
         # Initialize variables to track
@@ -32,9 +33,9 @@ class FunctionInspectorMixin:
         # Run the function to test it
         if data is None:
             if batched:
-                data = self[:2]
+                data = self[:2] if materialize else self.lz[:2]
             else:
-                data = self[0]
+                data = self[0] if materialize else self.lz[0]
 
         if indices is None:
             if batched:

--- a/mosaic/mixins/mapping.py
+++ b/mosaic/mixins/mapping.py
@@ -20,6 +20,7 @@ class MappableMixin:
         num_workers: Optional[int] = None,
         output_type: type = None,
         mmap: bool = False,
+        materialize: bool = True,
         **kwargs,
     ):
         # TODO (sabri): add materialize?
@@ -46,7 +47,9 @@ class MappableMixin:
 
         if not batched:
             # Convert to a batch function
-            function = self._convert_to_batch_fn(function, with_indices=with_indices)
+            function = self._convert_to_batch_fn(
+                function, with_indices=with_indices, materialize=materialize
+            )
             batched = True
             logger.info(f"Converting `function` {function} to a batched function.")
 
@@ -57,7 +60,8 @@ class MappableMixin:
                 self.batch(
                     batch_size=batch_size,
                     drop_last_batch=drop_last_batch,
-                    num_workers=num_workers
+                    num_workers=num_workers,
+                    materialize=materialize
                     # TODO: collate=batched was commented out in list_column
                 )
             ),
@@ -77,6 +81,7 @@ class MappableMixin:
                     batched,
                     batch,
                     range(start_index, end_index),
+                    materialize=materialize,
                 )
 
                 # Pull out information
@@ -150,5 +155,4 @@ class MappableMixin:
             outputs = outputs[0]
         else:
             outputs = DataPanel.from_batch(outputs)
-
         return outputs

--- a/mosaic/mixins/materialize.py
+++ b/mosaic/mixins/materialize.py
@@ -16,3 +16,6 @@ class _LazyIndexer:
 
     def __getitem__(self, index):
         return self.obj._get(index, materialize=False)
+
+    def __len__(self):
+        return len(self.obj)

--- a/mosaic/tools/utils.py
+++ b/mosaic/tools/utils.py
@@ -21,7 +21,9 @@ def transpose_dict_of_lists(d: Dict):
     return [dict(zip(d, t)) for t in zip(*d.values())]
 
 
-def convert_to_batch_column_fn(function: Callable, with_indices: bool):
+def convert_to_batch_column_fn(
+    function: Callable, with_indices: bool, materialize: bool = True
+):
     """Batch a function that applies to an example."""
 
     def _function(batch: Sequence, indices: Optional[List[int]], *args, **kwargs):
@@ -35,14 +37,14 @@ def convert_to_batch_column_fn(function: Callable, with_indices: bool):
             # Apply the unbatched function
             if with_indices:
                 output = function(
-                    batch[i],
+                    batch[i] if materialize else batch.lz[i],
                     indices[i],
                     *args,
                     **kwargs,
                 )
             else:
                 output = function(
-                    batch[i],
+                    batch[i] if materialize else batch.lz[i],
                     *args,
                     **kwargs,
                 )
@@ -70,7 +72,9 @@ def convert_to_batch_column_fn(function: Callable, with_indices: bool):
         return lambda batch, *args, **kwargs: _function(batch, None, *args, **kwargs)
 
 
-def convert_to_batch_fn(function: Callable, with_indices: bool):
+def convert_to_batch_fn(
+    function: Callable, with_indices: bool, materialize: bool = True
+):
     """Batch a function that applies to an example."""
 
     def _function(
@@ -86,14 +90,14 @@ def convert_to_batch_fn(function: Callable, with_indices: bool):
             # Apply the unbatched function
             if with_indices:
                 output = function(
-                    {k: v[i] for k, v in batch.items()},
+                    {k: v[i] if materialize else v.lz[i] for k, v in batch.items()},
                     indices[i],
                     *args,
                     **kwargs,
                 )
             else:
                 output = function(
-                    {k: v[i] for k, v in batch.items()},
+                    {k: v[i] if materialize else v.lz[i] for k, v in batch.items()},
                     *args,
                     **kwargs,
                 )

--- a/tests/testbeds.py
+++ b/tests/testbeds.py
@@ -141,7 +141,7 @@ class MockImageColumn:
         self.image_arrays = []
         self.images = []
 
-        for i in range(1, length + 1):
+        for i in range(0, length):
             self.image_paths.append(os.path.join(tmpdir, "{}.png".format(i)))
             self.image_arrays.append((i * np.ones((10, 10, 3))).astype(np.uint8))
             im = Image.fromarray(self.image_arrays[-1])


### PR DESCRIPTION
Other changes:
- Fix bug in update case when `visible_rows` is not `None` 
- Expand coverage of update tests to catch the bug above