### PR TITLE
Implement `head` and `tail` for `DataPanel` and columns

### DIFF
--- a/mosaic/columns/abstract.py
+++ b/mosaic/columns/abstract.py
@@ -144,7 +144,7 @@ class AbstractColumn(
         if isinstance(index, slice):
             # int or slice index => standard list slicing
             indices = np.arange(len(self))[index]
-        elif (isinstance(index, tuple) or isinstance(index, list)) and len(index):
+        elif isinstance(index, tuple) or isinstance(index, list):
             indices = np.array(index)
         elif isinstance(index, np.ndarray):
             if len(index.shape) != 1:
@@ -363,6 +363,14 @@ class AbstractColumn(
             return ListColumn(data)
         else:
             raise ValueError(f"Cannot create column out of data of type {type(data)}")
+
+    def head(self, n: int = 5) -> AbstractColumn:
+        """Get the first `n` examples of the column."""
+        return self.lz[:n]
+
+    def tail(self, n: int = 5) -> AbstractColumn:
+        """Get the last `n` examples of the column."""
+        return self.lz[-n:]
 
     def to_pandas(self) -> pd.Series:
         return pd.Series([self.lz[int(idx)] for idx in range(len(self))])

--- a/mosaic/datapanel.py
+++ b/mosaic/datapanel.py
@@ -111,7 +111,7 @@ class DataPanel(
 
         # Create attributes for all columns and visible columns
         self.all_columns = list(self._data.keys())
-        self.visible_columns = None
+        self._visible_columns = None
 
         # Create an identifier
         # TODO(Sabri): make _autobuild_identifier more informative
@@ -214,6 +214,20 @@ class DataPanel(
 
         # Set the features
         self._set_features()
+
+    @property
+    def visible_columns(self):
+        return self._visible_columns
+
+    @visible_columns.setter
+    def visible_columns(self, columns: Optional[Sequence[str]] = None):
+        if columns is None:
+            # do nothing, keep old visible columns
+            return
+
+        self._visible_columns = columns
+        if "index" not in self._visible_columns and "index" in self.all_columns:
+            self._visible_columns.append("index")
 
     @contextmanager
     def format(self, columns: List[str] = None):
@@ -371,10 +385,13 @@ class DataPanel(
         """Add an index to the dataset."""
         self.add_column("index", [str(i) for i in range(len(self))])
 
-    def head(self, n: int, columns: List[str] = None):
-        """View the first `n` examples of the dataset."""
-        with self.format(columns):
-            return pd.DataFrame(self[:n])
+    def head(self, n: int = 5) -> DataPanel:
+        """Get the first `n` examples of the DataPanel."""
+        return self.lz[:n]
+
+    def tail(self, n: int = 5) -> DataPanel:
+        """Get the last `n` examples of the DataPanel."""
+        return self.lz[-n:]
 
     def _create_logdir(self):
         """Create and assign a directory for logging this dataset's files."""
@@ -1045,7 +1062,7 @@ class DataPanel(
             "_identifier",
             "_data",
             "all_columns",
-            "visible_columns",
+            "_visible_columns",
             "_visible_rows",
             "_info",
             "_split",

--- a/tests/mosaic/test_datapanel.py
+++ b/tests/mosaic/test_datapanel.py
@@ -477,3 +477,47 @@ def test_to_pandas(tmpdir, use_visible_rows, use_visible_columns):
     if not use_visible_columns:
         assert isinstance(df["c"][0], dict)
         assert isinstance(df["img"][0], ImagePath)
+
+
+@pytest.mark.parametrize(
+    "use_visible_rows, use_visible_columns",
+    product([True, False], [True, False]),
+)
+def test_head(tmpdir, use_visible_rows, use_visible_columns):
+    length = 16
+    test_bed = MockDatapanel(
+        length=length,
+        use_visible_rows=use_visible_rows,
+        use_visible_columns=use_visible_columns,
+        tmpdir=tmpdir,
+    )
+    dp = test_bed.dp
+
+    new_dp = dp.head(n=2)
+
+    assert isinstance(new_dp, DataPanel)
+    assert new_dp.visible_columns == dp.visible_columns
+    assert len(new_dp) == 2
+    assert (new_dp["a"] == dp["a"][:2]).all()
+
+
+@pytest.mark.parametrize(
+    "use_visible_rows, use_visible_columns",
+    product([True, False], [True, False]),
+)
+def test_tail(tmpdir, use_visible_rows, use_visible_columns):
+    length = 16
+    test_bed = MockDatapanel(
+        length=length,
+        use_visible_rows=use_visible_rows,
+        use_visible_columns=use_visible_columns,
+        tmpdir=tmpdir,
+    )
+    dp = test_bed.dp
+
+    new_dp = dp.tail(n=2)
+
+    assert isinstance(new_dp, DataPanel)
+    assert new_dp.visible_columns == dp.visible_columns
+    assert len(new_dp) == 2
+    assert (new_dp["a"] == dp["a"][-2:]).all()


### PR DESCRIPTION
Other changes:
- Fix bug in AbstractColumn on empty index slices e.g. col[:0]
- Encapsulate `visible_columns`, so that we can enforce that "index" is always visible.