### PR TITLE
Add method `view` for getting new Column with the same underlying data

### DIFF
--- a/mosaic/columns/list_column.py
+++ b/mosaic/columns/list_column.py
@@ -4,6 +4,7 @@ import abc
 import logging
 from typing import Sequence
 
+import numpy as np
 import pandas as pd
 from yaml.representer import Representer
 
@@ -32,6 +33,25 @@ class ListColumn(AbstractColumn):
     @classmethod
     def from_list(cls, data: Sequence):
         return cls(data=data)
+
+    def _get_batch(self, indices: np.ndarray, materialize: bool = True) -> ListColumn:
+        """Get a batch of cells from the column.
+
+        Args:
+            index (int): This is an index into the ALL rows, not just visible rows. In
+                other words, we assume that the index passed in has already been
+                remapped via `_remap_index`, if `self.visible_rows` is not `None`.
+            materialize (bool, optional): Materialize and return the object. This
+                argument is used by subclasses of `AbstractColumn` that hold data in an
+                unmaterialized format. Defaults to False.
+        """
+        if materialize:
+            return self.collate([self._get_cell(int(i)) for i in indices])
+
+        else:
+            new_column = self.copy()
+            new_column._visible_rows = indices
+            return new_column
 
     def batch(
         self,

--- a/mosaic/columns/list_column.py
+++ b/mosaic/columns/list_column.py
@@ -4,7 +4,6 @@ import abc
 import logging
 from typing import Sequence
 
-import numpy as np
 import pandas as pd
 from yaml.representer import Representer
 
@@ -33,25 +32,6 @@ class ListColumn(AbstractColumn):
     @classmethod
     def from_list(cls, data: Sequence):
         return cls(data=data)
-
-    def _get_batch(self, indices: np.ndarray, materialize: bool = True) -> ListColumn:
-        """Get a batch of cells from the column.
-
-        Args:
-            index (int): This is an index into the ALL rows, not just visible rows. In
-                other words, we assume that the index passed in has already been
-                remapped via `_remap_index`, if `self.visible_rows` is not `None`.
-            materialize (bool, optional): Materialize and return the object. This
-                argument is used by subclasses of `AbstractColumn` that hold data in an
-                unmaterialized format. Defaults to False.
-        """
-        if materialize:
-            return self.collate([self._get_cell(int(i)) for i in indices])
-
-        else:
-            new_column = self.copy()
-            new_column._visible_rows = indices
-            return new_column
 
     def batch(
         self,

--- a/mosaic/datapanel.py
+++ b/mosaic/datapanel.py
@@ -23,7 +23,7 @@ from jsonlines import jsonlines
 import mosaic
 from mosaic.columns.abstract import AbstractColumn
 from mosaic.columns.cell_column import CellColumn
-from mosaic.mixins.copying import CopyMixin
+from mosaic.mixins.copying import DataPanelCopyMixin
 from mosaic.mixins.inspect_fn import FunctionInspectorMixin
 from mosaic.mixins.mapping import MappableMixin
 from mosaic.mixins.materialize import MaterializationMixin
@@ -40,7 +40,7 @@ BatchOrDataset = Union[Batch, "DataPanel"]
 
 class DataPanel(
     DatasetInfoMixin,
-    CopyMixin,
+    DataPanelCopyMixin,
     FunctionInspectorMixin,
     MappableMixin,
     MaterializationMixin,
@@ -156,6 +156,9 @@ class DataPanel(
             return 0
         return len(self[self.visible_columns[0]])
 
+    def __contains__(self, item):
+        return item in self.visible_columns
+
     def full_length(self):
         # If there are columns, full_length of any column, since they must be same size
         if self.column_names:
@@ -220,6 +223,9 @@ class DataPanel(
         if columns is None:
             # do nothing, keep old visible columns
             return
+        for c in columns:
+            if c not in self.all_columns:
+                raise ValueError(f"Trying to set nonexistant column {c} to visible.")
 
         self._visible_columns = copy(columns)
         if "index" not in self._visible_columns and "index" in self.all_columns:
@@ -338,8 +344,9 @@ class DataPanel(
 
         # Add the column
         self._data[name] = column
-        self.all_columns.append(name)
-        self.visible_columns.append(name)
+        if name not in self.all_columns:
+            self.all_columns.append(name)
+            self.visible_columns.append(name)
 
         # Set features
         self._set_features()
@@ -485,7 +492,7 @@ class DataPanel(
                 if not set(index).issubset(self.visible_columns):
                     missing_cols = set(self.visible_columns) - set(index)
                     raise ValueError(f"DataPanel does not have columns {missing_cols}")
-                dp = self.copy()
+                dp = self.view()
                 dp.visible_columns = index
                 return dp
 
@@ -829,7 +836,7 @@ class DataPanel(
         logger.info("Running update, a new dataset will be returned.")
 
         # Copy the ._data dict with a reference to the actual columns
-        new_dp = self.copy()
+        new_dp = self.view()
 
         # Calculate the values for the new columns using a .map()
         output = new_dp.map(
@@ -936,7 +943,7 @@ class DataPanel(
         indices = np.where(outputs)[0]
 
         # filter returns a new datapanel
-        new_datapanel = self.copy()
+        new_datapanel = self.view()
         for column in new_datapanel._data.values():
             column.visible_rows = indices
 
@@ -970,19 +977,15 @@ class DataPanel(
         )
 
     def items(self):
-        for name, column in self._data.items():
-            if name in self.visible_columns:
-                yield name, column
+        for name in self.visible_columns:
+            yield name, self._data[name]
 
     def keys(self):
-        for name in self._data.keys():
-            if name in self.visible_columns:
-                yield name
+        return self.visible_columns
 
     def values(self):
-        for name, column in self._data.items():
-            if name in self.visible_columns:
-                yield column
+        for name in self.visible_columns:
+            yield self._data[name]
 
     @classmethod
     def read(

--- a/mosaic/mixins/copying.py
+++ b/mosaic/mixins/copying.py
@@ -16,11 +16,11 @@ class AbstractCopyMixin(abc.ABC):
         return NotImplemented
 
     def view(self) -> object:
-        """When called on a column, returns a new column with the same underlying data,
-        but distinct views into that data (e.g. `AbstractColumn.visible_rows`,
-        `AbstractColumn._collate_fn`, and `DataPanel.visible_columns`).
-        Consider the following example:
-        ```
+        """When called on a column, returns a new column with the same
+        underlying data, but distinct views into that data (e.g.
+        `AbstractColumn.visible_rows`, `AbstractColumn._collate_fn`, and
+        `DataPanel.visible_columns`). Consider the following example: ```
+
             >>> column = ListColumn([0,0,0])
             >>> view = column.view()
             >>> view[0] = 10
@@ -45,7 +45,7 @@ class AbstractCopyMixin(abc.ABC):
         return self._copy(view=True)
 
     def copy(self) -> object:
-        """ Returns columns with a shallow copy of the underlying data."""
+        """Returns columns with a shallow copy of the underlying data."""
         return self._copy(view=False)
 
     def deepcopy(self) -> object:

--- a/mosaic/mixins/copying.py
+++ b/mosaic/mixins/copying.py
@@ -1,28 +1,66 @@
 from __future__ import annotations
 
+import abc
 import copy as pycopy
-from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mosaic import AbstractColumn, DataPanel
 
 
-class CopyMixin:
+class AbstractCopyMixin(abc.ABC):
     def __init__(self, *args, **kwargs):
-        super(CopyMixin, self).__init__(*args, **kwargs)
+        super(AbstractCopyMixin, self).__init__(*args, **kwargs)
+
+    def _copy(self, view: bool = False):
+        return NotImplemented
+
+    def view(self) -> object:
+        """When called on a column, returns a new column with the same underlying data,
+        but distinct views into that data (e.g. `AbstractColumn.visible_rows`,
+        `AbstractColumn._collate_fn`, and `DataPanel.visible_columns`).
+        Consider the following example:
+        ```
+            >>> column = ListColumn([0,0,0])
+            >>> view = column.view()
+            >>> view[0] = 10
+            >>> print(column[0] == view[0])
+            True
+            >>> view.visible_rows = [1,2]
+            >>> print(column[0] == view[0])
+            False
+        ```
+        When called on a DataPanel, returns a new DataPanel containing views of all the
+        columns in the original. Note: the underlying dictionary holding the columns
+        differs between the original and view DataPanels.
+        Consider the following example:
+        ```
+            >>> dp = DataPanel.from_csv(...)
+            >>> view = dp.view()
+            >>> view.add_column("new_col", ListColumn([0] * len(dp)))
+            >>> print("new_col" in dp)
+            False
+        ```
+        """
+        return self._copy(view=True)
 
     def copy(self) -> object:
-        """Return a copy of the object."""
+        """ Returns columns with a shallow copy of the underlying data."""
+        return self._copy(view=False)
 
+    def deepcopy(self) -> object:
+        """Return a deepcopy of the column or DataPanel."""
+        return pycopy.deepcopy(self)
+
+
+class ColumnCopyMixin(AbstractCopyMixin):
+    def _copy(self, view: bool = False) -> AbstractColumn:
+        """Return a copy of the object."""
         state = {}
         for k, v in self.__dict__.items():
-
-            # TODO: make this a nested map to cover sequences
-            # TODO (sabri): fix __new__ missing data for numpy array
-            if k == "_data" and isinstance(v, Mapping):
-                state[k] = {
-                    kp: pycopy.copy(vp) if not hasattr(vp, "copy") else vp.copy()
-                    for kp, vp in v.items()
-                }
-            elif k == "_data":
-                pass
+            if k == "_data" and view:
+                # don't copy the underlying data of the column if creating view
+                state[k] = v
             else:
                 state[k] = pycopy.copy(v)
 
@@ -36,6 +74,30 @@ class CopyMixin:
         obj.__dict__ = state
         return obj
 
-    def deepcopy(self) -> object:
-        """Return a deepcopy of the object."""
-        return pycopy.deepcopy(self)
+
+class DataPanelCopyMixin(AbstractCopyMixin):
+    def _copy(self, view: bool = False) -> DataPanel:
+        state = {}
+        for k, v in self.__dict__.items():
+
+            # TODO: make this a nested map to cover sequences
+            # TODO (sabri): fix __new__ missing data for numpy array
+            if k == "_data":
+                state[k] = {
+                    kp: pycopy.copy(vp)
+                    if not hasattr(vp, "copy")
+                    else vp._copy(view=view)
+                    for kp, vp in v.items()
+                }
+            else:
+                state[k] = pycopy.copy(v)
+
+        try:
+            obj = self.__class__(**state)
+        except TypeError:
+            # use `__new__` to instantiate a bare class, in case __init__ does work
+            # we do not want to repeat on copy
+            obj = self.__class__.__new__(self.__class__)
+
+        obj.__dict__ = state
+        return obj

--- a/mosaic/mixins/copying.py
+++ b/mosaic/mixins/copying.py
@@ -21,6 +21,8 @@ class CopyMixin:
                     kp: pycopy.copy(vp) if not hasattr(vp, "copy") else vp.copy()
                     for kp, vp in v.items()
                 }
+            elif k == "_data":
+                pass
             else:
                 state[k] = pycopy.copy(v)
 

--- a/mosaic/ops/merge.py
+++ b/mosaic/ops/merge.py
@@ -29,6 +29,9 @@ def merge(
         raise ValueError("Merge expects either `on` or `left_on` and `right_on`")
     left_on = on if left_on is None else left_on
     right_on = on if right_on is None else right_on
+    # cast `left_on` and `right_on` to lists
+    left_on = [left_on] if isinstance(left_on, str) else left_on
+    right_on = [right_on] if isinstance(right_on, str) else right_on
 
     # ensure we can merge on specified columns
     _check_merge_columns(left, left_on)
@@ -36,14 +39,15 @@ def merge(
 
     # convert datapanels to dataframes so we can apply Pandas merge
     # (1) only include columns we are joining on
-    left_on = [left_on] if isinstance(left_on, str) else left_on
-    right_on = [right_on] if isinstance(right_on, str) else right_on
     left_df = left[left_on].to_pandas()
     right_df = right[right_on].to_pandas()
     # (2) add index columns, which we'll use to reconstruct the columns we excluded from
     # the Pandas merge
     if ("__right_indices__" in right_df) or ("__left_indices__" in left_df):
-        raise ValueError("The column names '__right_indices__' and ")
+        raise ValueError(
+            "The column names '__right_indices__' and '__left_indices__' cannot appear "
+            "in the right and left panels respectively. They are used by merge."
+        )
     left_df["__left_indices__"] = np.arange(len(left_df))
     right_df["__right_indices__"] = np.arange(len(right_df))
 
@@ -59,48 +63,49 @@ def merge(
     )
     left_indices = merged_df.pop("__left_indices__").values
     right_indices = merged_df.pop("__right_indices__").values
+    merged_df = merged_df[set(left_on) & set(right_on)]
 
-    # reconstruct other columns not in the `left_on | right_on` using `left_indices`
+    # reconstruct other columns not in the `left_on & right_on` using `left_indices`
     # and `right_indices`, the row order returned by merge
-    merged_df = merged_df[set(left_on) | set(right_on)]
-    new_dps = []
-    for indices, dp in [(left_indices, left), (right_indices, right)]:
-        cols_to_create = [k for k in dp.keys() if k not in merged_df]
-        if np.isnan(indices).any():
-            # when performing "outer", "left", and "right" merges, column indices output
-            # by pandas merge can include `nan` in rows corresponding to merge keys that
-            # only appear in one of the two frames. For these columns, we convert the
-            # column to  ListColumn, and fill with "None" wherever indices is "nan".
-            data = {
-                name: ListColumn(
-                    [
-                        None if np.isnan(index) else col.lz[int(index)]
-                        for index in indices
-                    ]
-                )
-                for name, col in dp.items()
-                if name in cols_to_create
-            }
-            new_dp = DataPanel.from_batch(data)
-        else:
-            # if there are no `nan`s in the indices, then we can just lazy index the
-            # original column
-            new_dp = dp[cols_to_create].lz[indices]
-        new_dps.append(new_dp)
+    def _cols_to_construct(dp: DataPanel):
+        # don't construct columns in both `left_on` and `right_on` because we use
+        # `merged_df` for these
+        return [k for k in dp.keys() if k not in (set(left_on) & set(right_on))]
 
-    # concatenate the three datapanels (1) reconstructed from left indices,
-    # (2) reconstructed from right indices, (3) created out of the output of pandas
-    # merge
-    merged_dp = new_dps[0].append(new_dps[1], axis="columns", suffixes=suffixes)
-    merged_dp = DataPanel.from_pandas(merged_df).append(
-        merged_dp, axis="columns", overwrite=True
-    )
+    new_left = _construct_from_indices(left[_cols_to_construct(left)], left_indices)
+    new_right = _construct_from_indices(right[_cols_to_construct(right)], right_indices)
+
+    # concatenate the two new datapanels
+    merged_dp = new_left.append(new_right, axis="columns", suffixes=suffixes)
+
+    # add columns in both `left_on` and `right_on`, casting to the column type in left
+    for name, column in merged_df.iteritems():
+        merged_dp.add_column(name, left[name].__class__(data=column.values))
 
     if not keep_indexes:
         merged_dp.remove_column("index" + suffixes[0])
         merged_dp.remove_column("index" + suffixes[1])
 
     return merged_dp
+
+
+def _construct_from_indices(dp: DataPanel, indices: np.ndarray):
+    if np.isnan(indices).any():
+        # when performing "outer", "left", and "right" merges, column indices output
+        # by pandas merge can include `nan` in rows corresponding to merge keys that
+        # only appear in one of the two panels. For these columns, we convert the
+        # column to  ListColumn, and fill with "None" wherever indices is "nan".
+        data = {
+            name: ListColumn(
+                [None if np.isnan(index) else col.lz[int(index)] for index in indices]
+            )
+            for name, col in dp.items()
+        }
+        return DataPanel.from_batch(data)
+    else:
+        # if there are no `nan`s in the indices, then we can just lazy index the
+        # original column
+        return dp.lz[indices]
 
 
 def _check_merge_columns(dp: DataPanel, on: List[str]):

--- a/mosaic/ops/merge.py
+++ b/mosaic/ops/merge.py
@@ -81,6 +81,9 @@ def merge(
     # add columns in both `left_on` and `right_on`, casting to the column type in left
     for name, column in merged_df.iteritems():
         merged_dp.add_column(name, left[name].__class__(data=column.values))
+        merged_dp.visible_columns = (
+            merged_dp.visible_columns[-1:] + merged_dp.visible_columns[:-1]
+        )
 
     if not keep_indexes:
         merged_dp.remove_column("index" + suffixes[0])

--- a/tests/mosaic/ops/test_merge.py
+++ b/tests/mosaic/ops/test_merge.py
@@ -261,10 +261,17 @@ def test_merge_right(use_visible_rows, use_visible_columns, sort):
         assert list(out.lz[mask_2]["e_1"]) == [None] * len(mask_2)
 
 
+def test_merge_output_column_types():
+    dp1 = DataPanel.from_batch({"a": np.arange(3), "b": ListColumn(["1", "2", "3"])})
+    dp2 = dp1.copy()
+
+    out = dp1.merge(dp2, on="b", how="inner")
+    assert isinstance(out["b"], ListColumn)
+
+
 def test_cell_merge(tmpdir):
     length = 16
     img_col_test_bed = MockImageColumn(length=length, tmpdir=tmpdir)
-    # check dictionary not hashable
     dp1 = DataPanel.from_batch(
         {
             "a": np.arange(length),

--- a/tests/mosaic/ops/test_merge.py
+++ b/tests/mosaic/ops/test_merge.py
@@ -58,7 +58,7 @@ def get_dps(
                 column.visible_rows = visible_rows
 
         if use_visible_columns:
-            dp.visible_columns = visible_columns
+            dp.visible_columns = [c for c in visible_columns if c in dp.all_columns]
 
         dps.append(dp)
     return dps[0], dps[1], visible_rows, visible_columns, shuffle1, shuffle2


### PR DESCRIPTION
For very large DataPanels, filters and merges are very slow. This is because our current copy, actually copies the underlying data. Now, lazy indexing returns a view of the original column, without copying the underlying data using the `view` method, which is part of the copy mixin. 

Other related changes for speedup:
- Remove the list index for each column
- Updated `translate_index` to not create a np.arange for some types of indexes – still need to do this for all types of indexes and left some TODOs

Other fixes of merge:
- in `merge`, `check_merge_columns` assumes list inputs. If left_on or right_on is string, it fails.  move the check to after you cast to lists.
-  The join column gets cast into a numpy array rather than staying what it was before. So if a join column was a ListColumn, the output is it has now become a NumpyArray column. I think this is the to pandas conversion and inversion. This is now fixed.
- Column orders are now consistently: merge columns, left columns, right columns