### PR TITLE
Implement `mosaic.concat`

### DIFF
--- a/mosaic/__init__.py
+++ b/mosaic/__init__.py
@@ -21,4 +21,5 @@ from mosaic.columns.numpy_column import NumpyArrayColumn
 from mosaic.columns.spacy_column import SpacyColumn
 from mosaic.columns.tensor_column import TensorColumn
 from mosaic.datapanel import DataPanel
+from mosaic.ops.concat import concat
 from mosaic.ops.merge import merge

--- a/mosaic/columns/abstract.py
+++ b/mosaic/columns/abstract.py
@@ -68,16 +68,18 @@ class AbstractColumn(
         return f"{self.__class__.__name__}({reprlib.repr(self.data)})"
 
     def __str__(self):
-        if self.visible_rows is not None:
-            return (
-                f"{self.__class__.__name__}View"
-                f"({reprlib.repr([self.data[i] for i in self.visible_rows[:8]])})"
-            )
         return f"{self.__class__.__name__}({reprlib.repr(self.data)})"
 
     @property
     def data(self):
-        return self._data
+        """Get the underlying data (excluding invisible rows).
+
+        To access underlying data with invisible rows, use `_data`.
+        """
+        if self.visible_rows is not None:
+            return self._data[self.visible_rows]
+        else:
+            return self._data
 
     @property
     def metadata(self):
@@ -272,6 +274,12 @@ class AbstractColumn(
         return new_column
 
     def append(self, column: AbstractColumn) -> None:
+        # TODO(Sabri): implement a naive `ComposedColumn` for generic append and
+        # implement specific ones for ListColumn, NumpyColumn etc.
+        raise NotImplementedError
+
+    @staticmethod
+    def concat(columns: Sequence[AbstractColumn]) -> None:
         # TODO(Sabri): implement a naive `ComposedColumn` for generic append and
         # implement specific ones for ListColumn, NumpyColumn etc.
         raise NotImplementedError

--- a/mosaic/columns/cell_column.py
+++ b/mosaic/columns/cell_column.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Sequence
 
+import cytoolz as tz
 import numpy as np
 import pandas as pd
 
@@ -47,12 +48,15 @@ class CellColumn(AbstractColumn):
 
     @property
     def cells(self):
-        if self.visible_rows is None:
-            return self.data
-        else:
-            return [self.data[i] for i in self.visible_rows]
+        return self.data
 
     def _repr_pandas_(
         self,
     ) -> pd.Series:
         return pd.Series([cell.__repr__() for cell in self.cells])
+
+    @staticmethod
+    def concat(columns: Sequence[CellColumn]):
+        return columns[0].__class__.from_cells(
+            list(tz.concat([c.data for c in columns]))
+        )

--- a/mosaic/columns/list_column.py
+++ b/mosaic/columns/list_column.py
@@ -4,6 +4,7 @@ import abc
 import logging
 from typing import Sequence
 
+import cytoolz as tz
 import pandas as pd
 from yaml.representer import Representer
 
@@ -27,11 +28,24 @@ class ListColumn(AbstractColumn):
         *args,
         **kwargs,
     ):
+        if data is not None:
+            data = list(data)
         super(ListColumn, self).__init__(data=data, *args, **kwargs)
 
     @classmethod
     def from_list(cls, data: Sequence):
         return cls(data=data)
+
+    @property
+    def data(self):
+        """Get the underlying data (excluding invisible rows).
+
+        To access underlying data with invisible rows, use `_data`.
+        """
+        if self.visible_rows is not None:
+            return [self._data[row] for row in self.visible_rows]
+        else:
+            return self._data
 
     def batch(
         self,
@@ -51,3 +65,7 @@ class ListColumn(AbstractColumn):
 
     def _repr_pandas_(self) -> pd.Series:
         return pd.Series(map(repr, self))
+
+    @staticmethod
+    def concat(columns: Sequence[ListColumn]):
+        return ListColumn.from_list(list(tz.concat([c.data for c in columns])))

--- a/mosaic/columns/numpy_column.py
+++ b/mosaic/columns/numpy_column.py
@@ -48,13 +48,6 @@ class NumpyArrayColumn(
             data = np.asarray(data)
         super(NumpyArrayColumn, self).__init__(data=data, *args, **kwargs)
 
-    @property
-    def data(self):
-        if self.visible_rows is not None:
-            return self._data[self.visible_rows]
-        else:
-            return self._data
-
     _HANDLED_TYPES = (np.ndarray, numbers.Number)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
@@ -106,6 +99,10 @@ class NumpyArrayColumn(
 
     def _set_batch(self, indices, values):
         self._data[indices] = values
+
+    @staticmethod
+    def concat(columns: Sequence[NumpyArrayColumn]):
+        return NumpyArrayColumn.from_array(np.concatenate([c.data for c in columns]))
 
     @classmethod
     def get_writer(cls, mmap: bool = False):

--- a/mosaic/columns/tensor_column.py
+++ b/mosaic/columns/tensor_column.py
@@ -50,13 +50,6 @@ class TensorColumn(
             data = torch.as_tensor(data)
         super(TensorColumn, self).__init__(data=data, *args, **kwargs)
 
-    @property
-    def data(self):
-        if self.visible_rows is not None:
-            return self._data[self.visible_rows]
-        else:
-            return self._data
-
     def __torch_function__(self, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
@@ -83,6 +76,10 @@ class TensorColumn(
 
     def _set_batch(self, indices, values):
         self._data[indices] = values
+
+    @staticmethod
+    def concat(columns: Sequence[TensorColumn]):
+        return TensorColumn(torch.cat([c.data for c in columns]))
 
     @classmethod
     def get_writer(cls, mmap: bool = False):

--- a/mosaic/datapanel.py
+++ b/mosaic/datapanel.py
@@ -387,15 +387,7 @@ class DataPanel(
         """
         if axis == 0 or axis == "rows":
             # append new rows
-            if set(dp.visible_columns) != set(self.visible_columns):
-                unmatched_columns = set(dp.visible_columns) ^ set(self.visible_columns)
-                raise ValueError(
-                    "Can only append DataPanels along axis 0 (rows) if they have the "
-                    f"same columns. Columns in one but not both: {unmatched_columns}."
-                )
-            return DataPanel(
-                {self[column].append(dp[column]) for column in dp.visible_columns}
-            )
+            return mosaic.concat([self, dp], axis="rows")
         elif axis == 1 or axis == "columns":
             # append new columns
             if len(dp) != len(self):

--- a/mosaic/errors.py
+++ b/mosaic/errors.py
@@ -1,2 +1,6 @@
 class MergeError(ValueError):
     pass
+
+
+class ConcatError(ValueError):
+    pass

--- a/mosaic/ops/concat.py
+++ b/mosaic/ops/concat.py
@@ -11,16 +11,23 @@ def concat(
     objs: Union[Sequence[DataPanel], Sequence[AbstractColumn]],
     axis: Union[str, int] = "rows",
 ) -> Union[DataPanel, AbstractColumn]:
-    """Concatenate a sequence of columns or a sequence of datapanels.
-
-    If sequence is empty, returns an empty DataPanels.
+    """Concatenate a sequence of columns or a sequence of `DataPanel`s. If sequence is
+    empty, returns an empty `DataPanel`.
+    - If concatenating columns, all columns must be of the same type (e.g. all
+    `ListColumn`).
+    - If concatenating `DataPanel`s along axis 0 (rows), all `DataPanel`s must have the
+    same set of columns.
+    - If concatenating `DataPanel`s along axis 1 (columns), all `DataPanel`s must have
+    the same length and cannot have any of the same column names.
 
     Args:
-        objs (Union[Sequence[DataPanel], Sequence[AbstractColumn]]): [description]
+        objs (Union[Sequence[DataPanel], Sequence[AbstractColumn]]): sequence of columns
+            or DataPanels.
+        axis (Union[str, int]): The axis along which to concatenate. Ignored if
+            concatenating columns.
 
     Returns:
-        Union[DataPanel, AbstractColumn]: concatenated datapanel or column, depending on
-            type of objs.
+        Union[DataPanel, AbstractColumn]: concatenated DataPanel or column
     """
     if len(objs) == 0:
         return DataPanel()

--- a/mosaic/ops/concat.py
+++ b/mosaic/ops/concat.py
@@ -1,0 +1,68 @@
+from typing import Sequence, Union
+
+import cytoolz as tz
+
+from mosaic import DataPanel
+from mosaic.columns.abstract import AbstractColumn
+from mosaic.errors import ConcatError
+
+
+def concat(
+    objs: Union[Sequence[DataPanel], Sequence[AbstractColumn]],
+    axis: Union[str, int] = "rows",
+) -> Union[DataPanel, AbstractColumn]:
+    """Concatenate a sequence of columns or a sequence of datapanels.
+
+    If sequence is empty, returns an empty DataPanels.
+
+    Args:
+        objs (Union[Sequence[DataPanel], Sequence[AbstractColumn]]): [description]
+
+    Returns:
+        Union[DataPanel, AbstractColumn]: concatenated datapanel or column, depending on
+            type of objs.
+    """
+    if len(objs) == 0:
+        return DataPanel()
+
+    if not all([type(objs[0]) == type(obj) for obj in objs[1:]]):
+        raise ConcatError("All objects passed to concat must be of same type.")
+
+    if isinstance(objs[0], DataPanel):
+        if axis == 0 or axis == "rows":
+            # append new rows
+            columns = set(objs[0].visible_columns)
+            if not all([set(dp.visible_columns) == columns for dp in objs]):
+                raise ConcatError(
+                    "Can only concatenate DataPanels along axis 0 (rows) if they have "
+                    " the same set of columns names."
+                )
+            return DataPanel.from_batch(
+                {column: concat([dp[column] for dp in objs]) for column in columns}
+            )
+        elif axis == 1 or axis == "columns":
+            # append new columns
+            length = len(objs[0])
+            if not all([len(dp) == length for dp in objs]):
+                raise ConcatError(
+                    "Can only concatenate DataPanels along axis 1 (columns) if they "
+                    "have the same length."
+                )
+
+            columns = list(tz.concat((dp.visible_columns for dp in objs)))
+            columns.remove("index")  # need to remove index before checking distinct
+            if not tz.isdistinct(columns):
+                raise ConcatError(
+                    "Can only concatenate DataPanels along axis 1 (columns) if they "
+                    "have distinct column names."
+                )
+
+            data = tz.merge(*(dict(dp.items()) for dp in objs))
+            return DataPanel.from_batch(data)
+    elif isinstance(objs[0], AbstractColumn):
+        # use the concat method of the column
+        return objs[0].concat(objs)
+    else:
+        raise ConcatError(
+            "Must pass a sequence of datapanels or a sequence of columns to concat."
+        )

--- a/tests/mosaic/ops/test_concat.py
+++ b/tests/mosaic/ops/test_concat.py
@@ -1,0 +1,119 @@
+"""Unittests for Datasets."""
+from itertools import product
+
+import numpy as np
+import pytest
+
+from mosaic import concat
+from mosaic.columns.image_column import ImageColumn
+from mosaic.columns.list_column import ListColumn
+from mosaic.columns.numpy_column import NumpyArrayColumn
+from mosaic.columns.tensor_column import TensorColumn
+from mosaic.datapanel import DataPanel
+from mosaic.errors import ConcatError
+
+from ...testbeds import MockColumn, MockDatapanel, MockImageColumn
+
+
+@pytest.mark.parametrize(
+    "use_visible_rows,col_type,n",
+    product([True, False], [ListColumn, NumpyArrayColumn, TensorColumn], [1, 2, 3]),
+)
+def test_column_concat(use_visible_rows, col_type, n):
+    mock_col = MockColumn(use_visible_rows=use_visible_rows, col_type=col_type)
+    out = concat([mock_col.col] * n)
+
+    assert len(out) == len(mock_col.visible_rows) * n
+    assert isinstance(out, col_type)
+    assert list(out.data) == list(np.concatenate([mock_col.visible_rows] * n))
+
+
+@pytest.mark.parametrize(
+    "use_visible_rows,use_visible_columns,n",
+    product([True, False], [True, False], [1, 2, 3]),
+)
+def test_datapanel_row_concat(use_visible_rows, use_visible_columns, n):
+
+    mock_dp = MockDatapanel(
+        length=16,
+        use_visible_rows=use_visible_rows,
+        use_visible_columns=use_visible_columns,
+    )
+
+    out = concat([mock_dp.dp] * n, axis="rows")
+
+    assert len(out) == len(mock_dp.visible_rows) * n
+    assert isinstance(out, DataPanel)
+    assert set(out.visible_columns) == set(mock_dp.visible_columns)
+    assert (out["a"].data == np.concatenate([mock_dp.visible_rows] * n)).all()
+    assert out["b"].data == list(np.concatenate([mock_dp.visible_rows] * n))
+
+
+@pytest.mark.parametrize(
+    "use_visible_rows",
+    product([True, False]),
+)
+def test_datapanel_column_concat(use_visible_rows):
+
+    mock_dp = MockDatapanel(
+        length=16,
+        use_visible_rows=use_visible_rows,
+        use_visible_columns=False,
+    )
+
+    out = concat([mock_dp.dp[["a"]], mock_dp.dp[["b"]]], axis="columns")
+
+    assert len(out) == len(mock_dp.visible_rows)
+    assert isinstance(out, DataPanel)
+    assert set(out.visible_columns) == {"a", "b", "index"}
+    assert list(out["a"].data) == out["b"].data
+
+
+@pytest.mark.parametrize(
+    "use_visible_rows",
+    product([True, False]),
+)
+def test_image_column(use_visible_rows, tmpdir):
+
+    mock = MockImageColumn(length=16, tmpdir=tmpdir)
+
+    out = concat([mock.col.lz[:5], mock.col.lz[5:10]])
+
+    assert len(out) == 10
+    assert isinstance(out, ImageColumn)
+    assert [str(cell.filepath) for cell in out.lz] == mock.image_paths[:10]
+
+
+def test_concat_different_type():
+    a = NumpyArrayColumn.from_array([1, 2, 3])
+    b = ListColumn.from_list([1, 2, 3])
+    with pytest.raises(ConcatError):
+        concat([a, b])
+
+
+def test_concat_different_column_names():
+    a = DataPanel.from_batch({"a": [1, 2, 3]})
+    b = DataPanel.from_batch({"b": [1, 2, 3]})
+    with pytest.raises(ConcatError):
+        concat([a, b], axis="rows")
+
+
+def test_concat_different_lengths():
+    a = DataPanel.from_batch({"a": [1, 2, 3]})
+    b = DataPanel.from_batch({"b": [1, 2, 3, 4]})
+
+    with pytest.raises(ConcatError):
+        concat([a, b], axis="columns")
+
+
+def test_concat_same_columns():
+    a = DataPanel.from_batch({"a": [1, 2, 3]})
+    b = DataPanel.from_batch({"a": [1, 2, 3]})
+
+    with pytest.raises(ConcatError):
+        concat([a, b], axis="columns")
+
+
+def test_empty_concat():
+    out = concat([])
+    assert isinstance(out, DataPanel)

--- a/tests/testbeds.py
+++ b/tests/testbeds.py
@@ -6,6 +6,7 @@ import numpy as np
 from PIL import Image
 
 from mosaic.columns.image_column import ImageColumn
+from mosaic.columns.list_column import ListColumn
 from mosaic.datapanel import DataPanel
 from mosaic.tools.identifier import Identifier
 
@@ -105,7 +106,7 @@ class MockDatapanel:
     ):
         batch = {
             "a": np.arange(length),
-            "b": list(np.arange(length)),
+            "b": ListColumn(np.arange(length)),
             "c": [{"a": 2}] * length,
         }
 
@@ -116,7 +117,7 @@ class MockDatapanel:
 
         self.dp = DataPanel.from_batch(batch)
 
-        self.visible_rows = [0, 4, 6, 11] if use_visible_rows else None
+        self.visible_rows = [0, 4, 6, 11] if use_visible_rows else np.arange(length)
         if use_visible_rows:
             for column in self.dp.values():
                 column.visible_rows = self.visible_rows
@@ -126,6 +127,17 @@ class MockDatapanel:
         )
         if use_visible_columns:
             self.dp.visible_columns = self.visible_columns
+
+
+class MockColumn:
+    def __init__(self, use_visible_rows: bool = False, col_type: type = ListColumn):
+        self.col = col_type(np.arange(16))
+
+        if use_visible_rows:
+            self.visible_rows = [0, 4, 6, 11]
+            self.col.visible_rows = self.visible_rows
+        else:
+            self.visible_rows = np.arange(16)
 
 
 class MockImageColumn:


### PR DESCRIPTION
Add implementation of concat for DataPanel and core columns. Note: this does not work for speciality columns that haven't implemented `concat`. TODO: create a "composed column" which we can use for a default output of concat. 

Other changes:
- Whether `data` property shows invisible rows is inconsistent across different column types. Make all columns return only visible rows
- Add tests for concatenate  