### PR TITLE
rename batched -> is_batched_fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ new_col: ImageColumn = dp["image"][10:20]
 
     # updated_dp has two new `TensorColumn`s: 1 for probabilities and one
     # for predictions
-    updated_dp: DataPane = dp.update(function=predict, batch_size=128, batched=True)
+    updated_dp: DataPane = dp.update(function=predict, batch_size=128, is_batched_fn=True)
 ```
 
 **`DataPanel` is extendable.** Mosaic makes it easy for you to make custom column types for our data. The easiest way to do this is by subclassing `AbstractCell`. Subclasses of `AbstractCell` are meant to represent one element in one column of a `DataPanel`. For example, say we want our `DataPanel` to include a column of videos we have stored on disk. We want these videos to be lazily loaded using [scikit-video](http://www.scikit-video.org/stable/index.html), so we implement a `VideoCell` class as follows: 

--- a/mosaic/columns/abstract.py
+++ b/mosaic/columns/abstract.py
@@ -229,7 +229,7 @@ class AbstractColumn(
         function: Optional[Callable] = None,
         with_indices=False,
         input_columns: Optional[Union[str, List[str]]] = None,
-        batched: bool = False,
+        is_batched_fn: bool = False,
         batch_size: Optional[int] = 1,
         drop_last_batch: bool = False,
         num_workers: Optional[int] = 0,
@@ -250,7 +250,7 @@ class AbstractColumn(
 
         # Get some information about the function
         function_properties = self._inspect_function(
-            function, with_indices, batched=batched, materialize=materialize
+            function, with_indices, is_batched_fn=is_batched_fn, materialize=materialize
         )
         assert function_properties.bool_output, "function must return boolean."
 
@@ -260,7 +260,7 @@ class AbstractColumn(
             function=function,
             with_indices=with_indices,
             input_columns=input_columns,
-            batched=batched,
+            is_batched_fn=is_batched_fn,
             batch_size=batch_size,
             drop_last_batch=drop_last_batch,
             num_workers=num_workers,

--- a/mosaic/contrib/wilds/__init__.py
+++ b/mosaic/contrib/wilds/__init__.py
@@ -54,7 +54,7 @@ def get_wilds_datapane(
             out = torch.softmax(model(batch["input"].to(0)), axis=-1)
             return {"pred": out.cpu().numpy().argmax(axis=-1)}
 
-        dp = dp.update(function=predict, batch_size=128, batched=True)
+        dp = dp.update(function=predict, batch_size=128, is_batched_fn=True)
 
 
     Args:

--- a/mosaic/datapanel.py
+++ b/mosaic/datapanel.py
@@ -786,7 +786,7 @@ class DataPanel(
         function: Optional[Callable] = None,
         with_indices: bool = False,
         input_columns: Optional[Union[str, List[str]]] = None,
-        batched: bool = False,
+        is_batched_fn: bool = False,
         batch_size: Optional[int] = 1,
         remove_columns: Optional[List[str]] = None,
         num_workers: int = 0,
@@ -811,13 +811,13 @@ class DataPanel(
         # Get some information about the function
         with self.format(input_columns):
             function_properties = self._inspect_function(
-                function, with_indices, batched, materialize=materialize
+                function, with_indices, is_batched_fn, materialize=materialize
             )
             assert (
                 function_properties.dict_output
             ), f"`function` {function} must return dict."
 
-        if not batched:
+        if not is_batched_fn:
             # Convert to a batch function
             function = convert_to_batch_fn(
                 function, with_indices=with_indices, materialize=materialize
@@ -834,7 +834,7 @@ class DataPanel(
         output = new_dp.map(
             function=function,
             with_indices=with_indices,
-            batched=True,
+            is_batched_fn=True,
             batch_size=batch_size,
             num_workers=num_workers,
             input_columns=input_columns,
@@ -861,7 +861,7 @@ class DataPanel(
         function: Optional[Callable] = None,
         with_indices: bool = False,
         input_columns: Optional[Union[str, List[str]]] = None,
-        batched: bool = False,
+        is_batched_fn: bool = False,
         batch_size: Optional[int] = 1,
         drop_last_batch: bool = False,
         num_workers: int = 0,
@@ -876,7 +876,7 @@ class DataPanel(
             return super().map(
                 function=function,
                 with_indices=with_indices,
-                batched=batched,
+                is_batched_fn=is_batched_fn,
                 batch_size=batch_size,
                 drop_last_batch=drop_last_batch,
                 num_workers=num_workers,
@@ -892,7 +892,7 @@ class DataPanel(
         function: Optional[Callable] = None,
         with_indices=False,
         input_columns: Optional[Union[str, List[str]]] = None,
-        batched: bool = False,
+        is_batched_fn: bool = False,
         batch_size: Optional[int] = 1,
         drop_last_batch: bool = False,
         num_workers: int = 0,
@@ -915,7 +915,10 @@ class DataPanel(
         # Get some information about the function
         with self.format(input_columns):
             function_properties = self._inspect_function(
-                function, with_indices, batched=batched, materialize=materialize
+                function,
+                with_indices,
+                is_batched_fn=is_batched_fn,
+                materialize=materialize,
             )
             assert function_properties.bool_output, "function must return boolean."
 
@@ -925,7 +928,7 @@ class DataPanel(
             function=function,
             with_indices=with_indices,
             input_columns=input_columns,
-            batched=batched,
+            is_batched_fn=is_batched_fn,
             batch_size=batch_size,
             drop_last_batch=drop_last_batch,
             num_workers=num_workers,

--- a/mosaic/mixins/inspect_fn.py
+++ b/mosaic/mixins/inspect_fn.py
@@ -13,7 +13,7 @@ class FunctionInspectorMixin:
         self,
         function: Callable,
         with_indices: bool = False,
-        batched: bool = False,
+        is_batched_fn: bool = False,
         data=None,
         indices=None,
         materialize=True,
@@ -32,20 +32,20 @@ class FunctionInspectorMixin:
 
         # Run the function to test it
         if data is None:
-            if batched:
+            if is_batched_fn:
                 data = self[:2] if materialize else self.lz[:2]
             else:
                 data = self[0] if materialize else self.lz[0]
 
         if indices is None:
-            if batched:
+            if is_batched_fn:
                 indices = range(2)
             else:
                 indices = 0
 
-        if with_indices and batched:
+        if with_indices and is_batched_fn:
             output = function(data, indices)
-        elif with_indices and not batched:
+        elif with_indices and not is_batched_fn:
             output = function(data, indices)
         else:
             output = function(data)
@@ -84,7 +84,7 @@ class FunctionInspectorMixin:
         elif isinstance(output, (Sequence, AbstractColumn, torch.Tensor, np.ndarray)):
             # `function` returns a list
             list_output = True
-            if batched and (
+            if is_batched_fn and (
                 isinstance(output[0], (bool, np.bool_))
                 or (isinstance(output[0], np.ndarray) and (output[0].dtype == bool))
                 or (

--- a/mosaic/mixins/mapping.py
+++ b/mosaic/mixins/mapping.py
@@ -14,7 +14,7 @@ class MappableMixin:
         self,
         function: Optional[Callable] = None,
         with_indices: bool = False,
-        batched: bool = False,
+        is_batched_fn: bool = False,
         batch_size: Optional[int] = 1,
         drop_last_batch: bool = False,
         num_workers: Optional[int] = 0,
@@ -46,12 +46,12 @@ class MappableMixin:
             logger.info("Dataset empty, returning None.")
             return None
 
-        if not batched:
+        if not is_batched_fn:
             # Convert to a batch function
             function = self._convert_to_batch_fn(
                 function, with_indices=with_indices, materialize=materialize
             )
-            batched = True
+            is_batched_fn = True
             logger.info(f"Converting `function` {function} to a batched function.")
 
         # Run the map
@@ -80,7 +80,7 @@ class MappableMixin:
                 function_properties = self._inspect_function(
                     function,
                     with_indices,
-                    batched,
+                    is_batched_fn,
                     batch,
                     range(start_index, end_index),
                     materialize=materialize,

--- a/mosaic/ops/concat.py
+++ b/mosaic/ops/concat.py
@@ -11,8 +11,9 @@ def concat(
     objs: Union[Sequence[DataPanel], Sequence[AbstractColumn]],
     axis: Union[str, int] = "rows",
 ) -> Union[DataPanel, AbstractColumn]:
-    """Concatenate a sequence of columns or a sequence of `DataPanel`s. If sequence is
-    empty, returns an empty `DataPanel`.
+    """Concatenate a sequence of columns or a sequence of `DataPanel`s. If
+    sequence is empty, returns an empty `DataPanel`.
+
     - If concatenating columns, all columns must be of the same type (e.g. all
     `ListColumn`).
     - If concatenating `DataPanel`s along axis 0 (rows), all `DataPanel`s must have the

--- a/tests/mosaic/columns/test_numpy_column.py
+++ b/tests/mosaic/columns/test_numpy_column.py
@@ -69,7 +69,7 @@ def test_map_return_single(dtype, use_visible_rows, batched):
         out = x.mean(axis=-1)
         return out
 
-    result = col.map(func, batch_size=4, batched=batched)
+    result = col.map(func, batch_size=4, is_batched_fn=batched)
     assert isinstance(result, NumpyArrayColumn)
     np_test.assert_equal(len(result), len(array))
     assert (result == array.mean(axis=-1)).all()
@@ -86,7 +86,7 @@ def test_map_return_multiple(dtype, use_visible_rows, batched):
     def func(x):
         return {"mean": x.mean(axis=-1), "std": x.std(axis=-1)}
 
-    result = col.map(func, batch_size=4, batched=batched)
+    result = col.map(func, batch_size=4, is_batched_fn=batched)
     assert isinstance(result, DataPanel)
     assert isinstance(result["std"], NumpyArrayColumn)
     assert isinstance(result["mean"], NumpyArrayColumn)
@@ -140,7 +140,7 @@ def test_filter_1(use_visible_rows, dtype, batched):
     def func(x):
         return x > 20
 
-    result = col.filter(func, batch_size=4, batched=batched)
+    result = col.filter(func, batch_size=4, is_batched_fn=batched)
     assert isinstance(result, NumpyArrayColumn)
     assert len(result) == (array > 20).sum()
 

--- a/tests/mosaic/columns/test_tensor_column.py
+++ b/tests/mosaic/columns/test_tensor_column.py
@@ -69,7 +69,7 @@ def test_map_return_single(dtype, use_visible_rows, batched):
         out = x.type(torch.FloatTensor).mean(axis=-1)
         return out
 
-    result = col.map(func, batch_size=4, batched=batched)
+    result = col.map(func, batch_size=4, is_batched_fn=batched)
     assert isinstance(result, TensorColumn)
     np_test.assert_equal(len(result), len(array))
     assert np.allclose(result.numpy(), array.mean(axis=-1))
@@ -89,7 +89,7 @@ def test_map_return_multiple(dtype, use_visible_rows, batched):
             "std": x.type(torch.FloatTensor).std(axis=-1),
         }
 
-    result = col.map(func, batch_size=4, batched=batched)
+    result = col.map(func, batch_size=4, is_batched_fn=batched)
     assert isinstance(result, DataPanel)
     assert isinstance(result["std"], TensorColumn)
     assert isinstance(result["mean"], TensorColumn)

--- a/tests/mosaic/test_datapanel.py
+++ b/tests/mosaic/test_datapanel.py
@@ -192,7 +192,7 @@ def test_getitem(tmpdir, use_visible_rows):
     product([True, False], [True, False], [True, False], [0, 2]),
 )
 def test_map_1(use_visible_rows, use_visible_columns, use_input_columns, num_workers):
-    """`map`, mixed datapanel, single return, `batched=True`"""
+    """`map`, mixed datapanel, single return, `is_batched_fn=True`"""
     dp, visible_rows, visible_columns = _get_datapanel(
         use_visible_rows=use_visible_rows, use_visible_columns=use_visible_columns
     )
@@ -210,7 +210,7 @@ def test_map_1(use_visible_rows, use_visible_columns, use_input_columns, num_wor
     result = dp.map(
         func,
         batch_size=4,
-        batched=True,
+        is_batched_fn=True,
         num_workers=num_workers,
         input_columns=input_columns,
     )
@@ -224,7 +224,7 @@ def test_map_1(use_visible_rows, use_visible_columns, use_input_columns, num_wor
     product([True, False], [0, 2]),
 )
 def test_map_2(use_visible_rows, num_workers):
-    """`map`, mixed datapanel, return multiple, `batched=True`"""
+    """`map`, mixed datapanel, return multiple, `is_batched_fn=True`"""
     dp, visible_rows, visible_columns = _get_datapanel(
         use_visible_rows=use_visible_rows, use_visible_columns=False
     )
@@ -241,7 +241,7 @@ def test_map_2(use_visible_rows, num_workers):
     result = dp.map(
         func,
         batch_size=4,
-        batched=True,
+        is_batched_fn=True,
         num_workers=num_workers,
     )
     assert isinstance(result, DataPanel)
@@ -272,7 +272,11 @@ def test_update_1(use_visible_rows, use_visible_columns, use_input_columns, batc
 
     input_columns = ["a", "b"] if use_input_columns else None
     result = dp.update(
-        func, batch_size=4, batched=batched, num_workers=0, input_columns=input_columns
+        func,
+        batch_size=4,
+        is_batched_fn=batched,
+        num_workers=0,
+        input_columns=input_columns,
     )
     assert isinstance(result, DataPanel)
     assert set(result.visible_columns) == set(visible_columns + ["x"])
@@ -286,7 +290,7 @@ def test_update_1(use_visible_rows, use_visible_columns, use_input_columns, batc
 )
 def test_update_2(use_visible_rows, use_visible_columns, use_input_columns, batched):
     """`update`, mixed datapanel, return multiple, new columns,
-    `batched=True`"""
+    `is_batched_fn=True`"""
     dp, visible_rows, visible_columns = _get_datapanel(
         use_visible_rows=use_visible_rows, use_visible_columns=use_visible_columns
     )
@@ -303,7 +307,11 @@ def test_update_2(use_visible_rows, use_visible_columns, use_input_columns, batc
 
     input_columns = ["a", "b"] if use_input_columns else None
     result = dp.update(
-        func, batch_size=4, batched=batched, num_workers=0, input_columns=input_columns
+        func,
+        batch_size=4,
+        is_batched_fn=batched,
+        num_workers=0,
+        input_columns=input_columns,
     )
     assert isinstance(result, DataPanel)
     assert set(result.visible_columns) == set(visible_columns + ["x", "y"])
@@ -319,7 +327,7 @@ def test_update_2(use_visible_rows, use_visible_columns, use_input_columns, batc
 )
 def test_update_3(use_visible_rows, use_visible_columns, use_input_columns, batched):
     """`update`, mixed datapanel, return multiple, replace existing column,
-    `batched=True`"""
+    `is_batched_fn=True`"""
     dp, visible_rows, visible_columns = _get_datapanel(
         use_visible_rows=use_visible_rows, use_visible_columns=use_visible_columns
     )
@@ -336,7 +344,11 @@ def test_update_3(use_visible_rows, use_visible_columns, use_input_columns, batc
 
     input_columns = ["a", "b"] if use_input_columns else None
     result = dp.update(
-        func, batch_size=4, batched=batched, num_workers=0, input_columns=input_columns
+        func,
+        batch_size=4,
+        is_batched_fn=batched,
+        num_workers=0,
+        input_columns=input_columns,
     )
     assert isinstance(result, DataPanel)
     assert set(result.visible_columns) == set(visible_columns + ["y"])
@@ -359,7 +371,7 @@ def test_filter_1(use_visible_rows, use_visible_columns, batched):
     def func(x):
         return (x["a"] % 2) == 0
 
-    result = dp.filter(func, batch_size=4, batched=batched, num_workers=0)
+    result = dp.filter(func, batch_size=4, is_batched_fn=batched, num_workers=0)
     if visible_rows is None:
         visible_rows = np.arange(16)
 
@@ -403,7 +415,7 @@ def test_lz_map(tmpdir, use_visible_rows):
         assert isinstance(x["img"], ImageColumn)
         return [str(img.filepath) for img in x["img"].lz]
 
-    result = dp.map(func, materialize=False, num_workers=0, batched=True)
+    result = dp.map(func, materialize=False, num_workers=0, is_batched_fn=True)
 
     assert isinstance(result, ListColumn)
     assert result.data == [test_bed.img_col.image_paths[i] for i in visible_rows]
@@ -432,7 +444,7 @@ def test_lz_filter(tmpdir, use_visible_rows):
         # see `MockImageColumn` for filepath naming logic
         return (int(str(x["img"].filepath.name).split(".")[0]) % 2) == 0
 
-    result = dp.filter(func, batched=False, num_workers=0, materialize=False)
+    result = dp.filter(func, is_batched_fn=False, num_workers=0, materialize=False)
 
     assert isinstance(result, DataPanel)
     new_len = (np.array(visible_rows) % 2 == 0).sum()
@@ -456,7 +468,8 @@ def test_lz_filter(tmpdir, use_visible_rows):
     product([True, False]),
 )
 def test_lz_update(tmpdir, use_visible_rows: bool):
-    """`update`, mixed datapanel, return single, new columns, `batched=True`"""
+    """`update`, mixed datapanel, return single, new columns,
+    `is_batched_fn=True`"""
     length = 16
     test_bed = MockDatapanel(
         length=length,
@@ -476,7 +489,7 @@ def test_lz_update(tmpdir, use_visible_rows: bool):
         return out
 
     result = dp.update(
-        func, batch_size=4, batched=False, num_workers=0, materialize=False
+        func, batch_size=4, is_batched_fn=False, num_workers=0, materialize=False
     )
     assert set(result.column_names) == set(["a", "b", "c", "x", "img", "index"])
     assert len(result["x"]) == len(visible_rows)
@@ -496,7 +509,7 @@ def test_filter_2(use_visible_rows, use_visible_columns, batched):
     def func(x):
         return (x["a"] % 2) == 0
 
-    result = dp.filter(func, batch_size=4, batched=batched)
+    result = dp.filter(func, batch_size=4, is_batched_fn=batched)
     if visible_rows is None:
         visible_rows = np.arange(16)
 
@@ -522,7 +535,7 @@ def test_filter_2(use_visible_rows, use_visible_columns, batched):
     product([True, False], [True, False], [True, False]),
 )
 def test_io(tmp_path, write_together, use_visible_rows, use_visible_columns):
-    """`map`, mixed datapanel, return multiple, `batched=True`"""
+    """`map`, mixed datapanel, return multiple, `is_batched_fn=True`"""
     dp, visible_rows, visible_columns = _get_datapanel(
         use_visible_rows=use_visible_rows, use_visible_columns=use_visible_columns
     )


### PR DESCRIPTION
Rename `batched` to `is_batched_fn` to more clearly indicate to the user that the flag is referring to whether the function is batched or not.