### PR TITLE
Bug fix: Add support for torch ops on TensorColumn

### DIFF
--- a/mosaic/columns/prediction_column.py
+++ b/mosaic/columns/prediction_column.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Sequence, Union
 
+import numpy as np
+import pandas as pd
 import torch
 import torch.nn.functional as F
 from torch.distributions.categorical import Categorical
 
 from mosaic.columns.tensor_column import TensorColumn
+
+Columnable = Union[Sequence, np.ndarray, pd.Series, torch.Tensor]
 
 
 class _ClassifierOutputType(Enum):
@@ -49,9 +54,9 @@ class _ClassifierOutputType(Enum):
 class ClassificationOutputColumn(TensorColumn):
     def __init__(
         self,
-        logits=None,
-        probs=None,
-        preds=None,
+        logits: Columnable = None,
+        probs: Columnable = None,
+        preds: Columnable = None,
         num_classes: int = None,
         multi_label: bool = False,
         one_hot: bool = None,

--- a/tests/mosaic/columns/test_tensor_column.py
+++ b/tests/mosaic/columns/test_tensor_column.py
@@ -178,3 +178,25 @@ def test_copy(multiple_dim, dtype, use_visible_rows):
 
     assert isinstance(col_copy, TensorColumn)
     assert (col == col_copy).all()
+
+
+def test_tensor_ops():
+    """Test prototype tensor operations on tensor columns."""
+    col = TensorColumn(torch.ones(4, 3))
+
+    assert torch.all(torch.sum(col, dim=1) == 3)
+    assert torch.all(col.sum() == torch.sum(col))
+    assert torch.all(col.sum(dim=1) == torch.sum(col, dim=1))
+
+    assert torch.cat([col, col]).shape == (8, 3)
+    assert torch.vstack([col, col]).shape == (8, 3)
+    assert torch.cat([col, col, col], dim=1).shape == (4, 9)
+
+    assert torch.stack([col, col], dim=0).shape == (2, 4, 3)
+
+    chunk1, chunk2 = torch.chunk(col, chunks=2, dim=0)
+    assert chunk1.shape == (2, 3)
+    assert chunk2.shape == (2, 3)
+
+    col_nd = TensorColumn(torch.ones(4, 3, 5, 6))
+    assert col_nd.permute(3, 2, 1, 0).shape == col_nd.shape[::-1]


### PR DESCRIPTION
This PR adds support for `torch.XX` ops:

- [x] Support standard prototypical tensor ops (sum, cat, stack, etc.)
- [x] Support arguments where tensors are wrapped in container structures (lists, tuples, dicts)
- [x] Support outputs where tensors are wrapped in container structures (lists, tuples, dicts)

Resolves #47 