### PR TITLE
bug fix: have ops on subclassed datapanels return subclass type

### DIFF
--- a/mosaic/datapanel.py
+++ b/mosaic/datapanel.py
@@ -427,7 +427,7 @@ class DataPanel(
             else:
                 data = {**dict(self.items()), **dict(dp.items())}
 
-            return DataPanel.from_batch(data)
+            return self.from_batch(data)
         else:
             raise ValueError("DataPanel `axis` must be either 0 or 1.")
 
@@ -490,7 +490,7 @@ class DataPanel(
         # cases where `index` returns a datapanel
         elif isinstance(index, slice):
             # slice index => multiple row selection (DataPanel)
-            return DataPanel.from_batch(
+            return self.from_batch(
                 {
                     k: self._data[k]._get(index, materialize=materialize)
                     for k in self.visible_columns
@@ -507,7 +507,7 @@ class DataPanel(
                 dp.visible_columns = index
                 return dp
 
-            return DataPanel.from_batch(
+            return self.from_batch(
                 {
                     k: self._data[k]._get(index, materialize=materialize)
                     for k in self.visible_columns
@@ -519,7 +519,7 @@ class DataPanel(
                     "Index must have 1 axis, not {}".format(len(index.shape))
                 )
             # numpy array index => multiple row selection (DataPanel)
-            return DataPanel.from_batch(
+            return self.from_batch(
                 {
                     k: self._data[k]._get(index, materialize=materialize)
                     for k in self.visible_columns
@@ -527,7 +527,7 @@ class DataPanel(
             )
         elif isinstance(index, AbstractColumn):
             # column index => multiple row selection (DataPanel)
-            return DataPanel.from_batch(
+            return self.from_batch(
                 {
                     k: self._data[k]._get(index, materialize=materialize)
                     for k in self.visible_columns
@@ -742,7 +742,7 @@ class DataPanel(
         new_batch = {}
         for name, values in batch.items():
             new_batch[name] = column_to_collate[name](values)
-        dp = DataPanel.from_batch(new_batch)
+        dp = self.from_batch(new_batch)
         return dp
 
     @staticmethod
@@ -810,7 +810,7 @@ class DataPanel(
 
         if batch_columns and cell_columns:
             for cell_batch, batch_batch in zip(cell_dl, batch_dl):
-                yield DataPanel.from_batch({**cell_batch._data, **batch_batch._data})
+                yield self.from_batch({**cell_batch._data, **batch_batch._data})
         elif batch_columns:
             for batch_batch in batch_dl:
                 yield batch_batch

--- a/mosaic/datapanel.py
+++ b/mosaic/datapanel.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 from contextlib import contextmanager
 from copy import copy, deepcopy
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import cytoolz as tz
 import datasets
@@ -427,7 +427,7 @@ class DataPanel(
             else:
                 data = {**dict(self.items()), **dict(dp.items())}
 
-            return self.from_batch(data)
+            return self._clone(data=data)
         else:
             raise ValueError("DataPanel `axis` must be either 0 or 1.")
 
@@ -490,8 +490,8 @@ class DataPanel(
         # cases where `index` returns a datapanel
         elif isinstance(index, slice):
             # slice index => multiple row selection (DataPanel)
-            return self.from_batch(
-                {
+            return self._clone(
+                data={
                     k: self._data[k]._get(index, materialize=materialize)
                     for k in self.visible_columns
                 }
@@ -507,8 +507,8 @@ class DataPanel(
                 dp.visible_columns = index
                 return dp
 
-            return self.from_batch(
-                {
+            return self._clone(
+                data={
                     k: self._data[k]._get(index, materialize=materialize)
                     for k in self.visible_columns
                 }
@@ -519,16 +519,16 @@ class DataPanel(
                     "Index must have 1 axis, not {}".format(len(index.shape))
                 )
             # numpy array index => multiple row selection (DataPanel)
-            return self.from_batch(
-                {
+            return self._clone(
+                data={
                     k: self._data[k]._get(index, materialize=materialize)
                     for k in self.visible_columns
                 }
             )
         elif isinstance(index, AbstractColumn):
             # column index => multiple row selection (DataPanel)
-            return self.from_batch(
-                {
+            return self._clone(
+                data={
                     k: self._data[k]._get(index, materialize=materialize)
                     for k in self.visible_columns
                 }
@@ -742,7 +742,7 @@ class DataPanel(
         new_batch = {}
         for name, values in batch.items():
             new_batch[name] = column_to_collate[name](values)
-        dp = self.from_batch(new_batch)
+        dp = self._clone(data=new_batch)
         return dp
 
     @staticmethod
@@ -810,7 +810,7 @@ class DataPanel(
 
         if batch_columns and cell_columns:
             for cell_batch, batch_batch in zip(cell_dl, batch_dl):
-                yield self.from_batch({**cell_batch._data, **batch_batch._data})
+                yield self._clone(data={**cell_batch._data, **batch_batch._data})
         elif batch_columns:
             for batch_batch in batch_dl:
                 yield batch_batch
@@ -1112,3 +1112,26 @@ class DataPanel(
             "_info",
             "_split",
         }
+
+    def _clone_kwargs(self) -> Dict[str, Any]:
+        """Returns __init__ kwargs for instantiating new object.
+
+        This function returns the default parameters that should be plumbed
+        from the current instance to the new instance.
+
+        This is the API that should be used by subclasses of :class:`DataPanel`.
+
+        Returns:
+            Dict[str, Any]: The keyword arguments for initialization
+        """
+        # identifier, info, and split are not passed by default because they have
+        # not been plumbed so far.
+        return {}
+
+    def _clone(self, data=None, **kwargs):
+        default_kwargs = self._clone_kwargs()
+        if data is None:
+            data = kwargs.pop("data", self.data)
+        if kwargs:
+            default_kwargs.update(kwargs)
+        return self.__class__(data, **default_kwargs)

--- a/mosaic/mixins/mapping.py
+++ b/mosaic/mixins/mapping.py
@@ -161,6 +161,9 @@ class MappableMixin:
         else:
             # TODO (arjundd): This is duck type. We should probably make this
             # class signature explicit.
-            klass = type(self) if isinstance(self, DataPanel) else DataPanel
-            outputs = klass.from_batch(outputs)
+            outputs = (
+                self._clone(data=outputs)
+                if isinstance(self, DataPanel)
+                else DataPanel.from_batch(outputs)
+            )
         return outputs

--- a/mosaic/mixins/mapping.py
+++ b/mosaic/mixins/mapping.py
@@ -159,5 +159,8 @@ class MappableMixin:
         if not is_mapping:
             outputs = outputs[0]
         else:
-            outputs = DataPanel.from_batch(outputs)
+            # TODO (arjundd): This is duck type. We should probably make this
+            # class signature explicit.
+            klass = type(self) if isinstance(self, DataPanel) else DataPanel
+            outputs = klass.from_batch(outputs)
         return outputs

--- a/mosaic/ops/concat.py
+++ b/mosaic/ops/concat.py
@@ -47,7 +47,7 @@ def concat(
                     "Can only concatenate DataPanels along axis 0 (rows) if they have "
                     " the same set of columns names."
                 )
-            return DataPanel.from_batch(
+            return objs[0].from_batch(
                 {column: concat([dp[column] for dp in objs]) for column in columns}
             )
         elif axis == 1 or axis == "columns":
@@ -68,7 +68,7 @@ def concat(
                 )
 
             data = tz.merge(*(dict(dp.items()) for dp in objs))
-            return DataPanel.from_batch(data)
+            return objs[0].from_batch(data)
     elif isinstance(objs[0], AbstractColumn):
         # use the concat method of the column
         return objs[0].concat(objs)

--- a/mosaic/ops/merge.py
+++ b/mosaic/ops/merge.py
@@ -106,7 +106,7 @@ def _construct_from_indices(dp: DataPanel, indices: np.ndarray):
             )
             for name, col in dp.items()
         }
-        return DataPanel.from_batch(data)
+        return dp.from_batch(data)
     else:
         # if there are no `nan`s in the indices, then we can just lazy index the
         # original column

--- a/mosaic/pipelines/entitydatapanel.py
+++ b/mosaic/pipelines/entitydatapanel.py
@@ -1,4 +1,4 @@
-"""EntityDataPanel Class"""
+"""EntityDataPanel Class."""
 import logging
 from typing import Any, Dict, List, Sequence, Tuple, Union
 
@@ -76,30 +76,43 @@ class EntityDataPanel(DataPanel):
         embedding_columns: List[str] = None,
         index_column: str = None,
     ):
-        """Returns EntityDataPanel DP from standard DP"""
+        """Returns EntityDataPanel DP from standard DP."""
         return cls(
             datapanel._data,
             embedding_columns=embedding_columns,
             index_column=index_column,
         )
 
-    def to_datapanel(self):
-        """Casts to a DataPanel"""
-        return DataPanel.from_batch({k: self[k] for k in self.visible_columns})
+    def to_datapanel(self, klass: type = None):
+        """Casts to a DataPanel.
+
+        Args:
+            klass (type): If specified, casts to this class.
+                This class must be a subclass of :ref:`mosaic.datapanel.DataPanel`.
+                If not specified, defaults to :ref:`mosaic.datapanel.DataPanel`.
+
+        Returns:
+            DataPanel: The datapanel.
+        """
+        if klass is None:
+            klass = DataPanel
+        elif not issubclass(klass, DataPanel):
+            raise ValueError("`klass` must be a subclass of DataPanel")
+        return klass.from_batch({k: self[k] for k in self.visible_columns})
 
     @property
     def index(self):
-        "Returns index column"
+        """Returns index column."""
         return self[self.index_column]
 
     @property
     def embedding_columns(self):
-        """Returns _visible_ embedding columns"""
+        """Returns _visible_ embedding columns."""
         return [e for e in self._embedding_columns if e in self.visible_columns]
 
     @property
     def index_column(self):
-        """Returns index column"""
+        """Returns index column."""
         return self._index_column
 
     def _check_index_unique(self):
@@ -108,11 +121,11 @@ class EntityDataPanel(DataPanel):
         ), "Index must be unique and hashable"
 
     def icontain(self, idx: Any):
-        """Checks if idx in the index column or not"""
+        """Checks if idx in the index column or not."""
         return idx in self._index_to_rowid
 
     def iget(self, idx: Any):
-        """Gets the row given the entity index"""
+        """Gets the row given the entity index."""
         if not isinstance(idx, type(next(iter(self._index_to_rowid.keys())))):
             raise ValueError(
                 "Query must be the same type as the index column of the data"
@@ -128,9 +141,11 @@ class EntityDataPanel(DataPanel):
         return self[row_idx]
 
     def _get(self, index, materialize: bool = False):
-        """When _get returns a DataPanel with same columns,
-        cast back to EntityDataPanel"""
+        """When _get returns a DataPanel with same columns, cast back to
+        EntityDataPanel."""
         ret = super(EntityDataPanel, self)._get(index, materialize)
+        self._remove_ent_idx_column(ret)
+
         # If _get subselects columns and _removes_ the index column, this is no longer
         # an EntityDataPanel. In DataPanel, a column subselection will not recast to
         # a DataPanel (it just creates a view). In this case, we need to explicitly cast
@@ -149,15 +164,18 @@ class EntityDataPanel(DataPanel):
         return ret
 
     def _add_ent_index(self):
-        """Add an integer index to the dataset. Not using index from DataPanel
-        as ids need to be integers to serve as embedding row indices"""
+        """Add an integer index to the dataset.
+
+        Not using index from DataPanel as ids need to be integers to
+        serve as embedding row indices
+        """
         # TODO: Why do you have a string index...feels weird and expensive.
         # with row indexes due to filtering.
         self.add_column("_ent_index", [i for i in range(len(self))])
         self._index_column = "_ent_index"
 
     def _cast_to_embedding(self, name):
-        """Cast column to Embedding column if not already"""
+        """Cast column to Embedding column if not already."""
         if not isinstance(self._data[name], EmbeddingColumn):
             self._data[name] = EmbeddingColumn(self._data[name])
 
@@ -168,8 +186,11 @@ class EntityDataPanel(DataPanel):
         index_to_rowid: Dict[Any, int] = None,
         overwrite: bool = False,
     ):
-        """Adds embedding column to data. If index_to_rowid provided,
-        maps DP index column to rowid of embedding."""
+        """Adds embedding column to data.
+
+        If index_to_rowid provided, maps DP index column to rowid of
+        embedding.
+        """
         if index_to_rowid is not None:
             permutation = [index_to_rowid[i] for i in self.index]
             embedding = embedding[permutation]
@@ -184,7 +205,10 @@ class EntityDataPanel(DataPanel):
             self._embedding_columns.append(name)
 
     def remove_column(self, column: str) -> None:
-        """Remove column. Assert index column is not removed"""
+        """Remove column.
+
+        Assert index column is not removed
+        """
         assert column != self.index_column, "Can't remove an index column"
         super(EntityDataPanel, self).remove_column(column)
         if column in self._embedding_columns:
@@ -197,12 +221,11 @@ class EntityDataPanel(DataPanel):
         suffixes: Tuple[str] = None,
         overwrite: bool = False,
     ) -> "EntityDataPanel":
-        """
-        Append an EntityDataPanel.
-        """
+        """Append an EntityDataPanel."""
         if axis == 0 or axis == "rows":
             # append new rows
             ret = super(EntityDataPanel, self).append(dp, axis, suffixes, overwrite)
+            self._remove_ent_idx_column(ret)
             return EntityDataPanel.from_datapanel(
                 ret,
                 embedding_columns=self.embedding_columns,
@@ -223,6 +246,7 @@ class EntityDataPanel(DataPanel):
             if self.index_column in dp.column_names and not overwrite:
                 new_index_column += suffixes[0]
             ret = super(EntityDataPanel, self).append(dp, axis, suffixes, overwrite)
+            self._remove_ent_idx_column(ret)
             return EntityDataPanel.from_datapanel(
                 ret,
                 embedding_columns=new_embedding_cols,
@@ -241,8 +265,11 @@ class EntityDataPanel(DataPanel):
         validate=None,
         keep_indexes: bool = False,
     ):
-        """Perform merge of two EntityDPs. By default we merge both on their index columns.
-        We do allow for changing the join column of the left side"""
+        """Perform merge of two EntityDPs.
+
+        By default we merge both on their index columns. We do allow for
+        changing the join column of the left side
+        """
         left_on = left_on if left_on is not None else self.index_column
         new_embedding_cols = self._get_merged_embedding_columns(
             right, overwrite=False, suffixes=suffixes
@@ -285,8 +312,11 @@ class EntityDataPanel(DataPanel):
 
     def _get_merged_embedding_columns(self, dp, overwrite, suffixes):
         """In order to create EntityDataPanel post merge/append, we need to
-        have the embedding columns. This calculates the new EntityDataPanel
-        embedding columns in the case of suffix changes."""
+        have the embedding columns.
+
+        This calculates the new EntityDataPanel embedding columns in the
+        case of suffix changes.
+        """
         new_embedding_cols = self.embedding_columns + dp.embedding_columns
         # Capture the new embedding columns before merging
         if len(set(self.embedding_columns).intersection(dp.embedding_columns)) > 0:
@@ -322,7 +352,9 @@ class EntityDataPanel(DataPanel):
         self, column: Union[ListColumn, TensorColumn, NumpyArrayColumn]
     ):
         """Maps column of entity idx to their row ids for the embeddings.
-        Used in data prep before training."""
+
+        Used in data prep before training.
+        """
 
         def recursive_map(seq):
             if isinstance(seq, (np.ndarray, torch.Tensor, list)):
@@ -344,7 +376,7 @@ class EntityDataPanel(DataPanel):
         query_embedding_column=None,
         search_embedding_column=None,
     ):
-        """Returns most similar entities distinct from query"""
+        """Returns most similar entities distinct from query."""
         assert k < len(self), "k must be less than the total number of entities"
         if query_embedding_column is None:
             query_embedding_column = self.embedding_columns[0]
@@ -379,3 +411,19 @@ class EntityDataPanel(DataPanel):
             "_embedding_columns",
             "_index_column",
         }
+
+    def _remove_ent_idx_column(self, dp: DataPanel):
+        """Removes '_ent_idx' column from datapanel.
+
+        DataPanel._get() calls self.from_batch, which calls the constructor for the
+        subclassed DataPanel. In this case, it calls the constructor without setting
+        index_column, which results in an extra column.
+        This is a stopgap solution to remove the index column from the returned
+        DataPanel if it is already set in the current EntityDataPanel.
+
+        TODO (arjundd): Fix this.
+        """
+        if isinstance(dp, EntityDataPanel) and (self.index_column is not None):
+            dp._index_column = self.index_column
+            if dp.index_column != "_ent_index":
+                dp.remove_column("_ent_index")

--- a/mosaic/provenance.py
+++ b/mosaic/provenance.py
@@ -14,6 +14,7 @@ _provenance_enabled = False
 class provenance:
     def __init__(self, enabled: bool = True):
         """Context manager for enabling provenance capture in Mosaic.
+
         Example:
         ```python
         import mosaic as ms

--- a/mosaic/tools/lazy_loader.py
+++ b/mosaic/tools/lazy_loader.py
@@ -59,8 +59,8 @@ class LazyLoader(types.ModuleType):
         # Import the target module and insert it into the parent's namespace
         try:
             module = importlib.import_module(self.__name__)
-        except ImportError:
-            raise ImportError(self._error) if self._error else ImportError
+        except ImportError as e:
+            raise ImportError(self._error) if self._error else e
         self._parent_module_globals[self._local_name] = module
 
         # Emit a warning if one was specified

--- a/tests/mosaic/test_datapanel.py
+++ b/tests/mosaic/test_datapanel.py
@@ -656,3 +656,23 @@ def test_append_columns(use_visible_rows, use_visible_columns):
     assert set(out.visible_columns) == set(mock.visible_columns)
     assert (out["a"].data == np.concatenate([mock.visible_rows] * 2)).all()
     assert out["b"].data == list(np.concatenate([mock.visible_rows] * 2))
+
+
+class DataPanelSubclass(DataPanel):
+    """Mock class to test that ops on subclass returns subclass."""
+
+    pass
+
+
+def test_subclass():
+    dp1 = DataPanelSubclass.from_dict({"a": np.arange(3), "b": ["may", "jun", "jul"]})
+    dp2 = DataPanelSubclass.from_dict(
+        {"c": np.arange(3), "d": ["2021", "2022", "2023"]}
+    )
+
+    assert isinstance(dp1.lz[np.asarray([0, 1])], DataPanelSubclass)
+    assert isinstance(dp1.lz[:2], DataPanelSubclass)
+    assert isinstance(dp1[:2], DataPanelSubclass)
+
+    assert isinstance(dp1.merge(dp2, left_on="a", right_on="c"), DataPanelSubclass)
+    assert isinstance(dp1.append(dp1), DataPanelSubclass)


### PR DESCRIPTION
## Issue
When datapanels are subclasses, ops on these datapanels (__getitem__, merge, append, etc) returned instances of `mosaic.DataPanel` instead of the subclass type

## Fix
All class methods can be called from the instance. This will automatically pass the type of the instance (e.g. subclass) to the class method. For example,
```python
import mosaic as ms
class DataPanelSubclass(ms.DataPanel):
    pass

dp = DataPanelSubclass(...)
dp.from_batch(...)  # called with cls=DataPanelSubclass
```

When `from_batch` is used from instance methods, we call `self.from_batch` instead of `DataPanel.from_batch`.

## Consequences and stopgap solutions
By calling `self.from_batch`, the initializer of the **subclass** is called as `from_batch` calls `cls(...)`. This can be an issue if there is state in the current instance (e.g. `self`) that needs to be passed to the new DataPanel subclass instance. 

An example of this is `EntityDataPanel`, where the `index_column` should be passed from the current instance to the newly constructed instance. Because there is no way to plumb that information through different calls, the initializer of `EntityDataPanel` gets called with `EntityDataPanel(index_column=None)` even if the current instance has an index column. This results in a new column `"_ent_index"` being added to the new EntityDataPanel.

As a stopgap solution, we have a method that removes the extra `"_ent_idx"` column any time a new data panel is created, but this is not a scalable solution, because there may be many parameters that need to be plumbed through to construct the subclassed data panel.

We propose a more long-term solution in #56 