### PR TITLE
Use cloneable design pattern to fix mmap and general mapping with complex column types

### DIFF
--- a/mosaic/__init__.py
+++ b/mosaic/__init__.py
@@ -18,6 +18,7 @@ from mosaic.columns.embedding_column import EmbeddingColumn
 from mosaic.columns.image_column import ImageColumn
 from mosaic.columns.list_column import ListColumn
 from mosaic.columns.numpy_column import NumpyArrayColumn
+from mosaic.columns.prediction_column import ClassificationOutputColumn
 from mosaic.columns.spacy_column import SpacyColumn
 from mosaic.columns.tensor_column import TensorColumn
 from mosaic.datapanel import DataPanel

--- a/mosaic/columns/embedding_column.py
+++ b/mosaic/columns/embedding_column.py
@@ -39,14 +39,6 @@ class EmbeddingColumn(TensorColumn):
 
         self.faiss_index = None
 
-    @classmethod
-    def from_data(cls, data: Union[Columnable, AbstractColumn]):
-        """Convert data to an EmbeddingColumn."""
-        if torch.is_tensor(data):
-            return EmbeddingColumn(data)
-        else:
-            return super(EmbeddingColumn, cls).from_data(data)
-
     def build_faiss_index(self, index=None, overwrite=False):
         if self.ndim < 2:
             raise ValueError("Building an index requires `ndim` >= 2.")

--- a/mosaic/columns/embedding_column.py
+++ b/mosaic/columns/embedding_column.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 import torch
 
-from mosaic import AbstractColumn
 from mosaic.columns.tensor_column import TensorColumn
 from mosaic.tools.lazy_loader import LazyLoader
 

--- a/mosaic/datapanel.py
+++ b/mosaic/datapanel.py
@@ -23,6 +23,7 @@ from jsonlines import jsonlines
 import mosaic
 from mosaic.columns.abstract import AbstractColumn
 from mosaic.columns.cell_column import CellColumn
+from mosaic.mixins.cloneable import CloneableMixin
 from mosaic.mixins.copying import DataPanelCopyMixin
 from mosaic.mixins.inspect_fn import FunctionInspectorMixin
 from mosaic.mixins.mapping import MappableMixin
@@ -40,6 +41,7 @@ BatchOrDataset = Union[Batch, "DataPanel"]
 
 
 class DataPanel(
+    CloneableMixin,
     DataPanelCopyMixin,
     FunctionInspectorMixin,
     MappableMixin,
@@ -831,6 +833,7 @@ class DataPanel(
         batch_size: Optional[int] = 1,
         remove_columns: Optional[List[str]] = None,
         num_workers: int = 0,
+        mmap: bool = False,
         materialize: bool = True,
         pbar: bool = False,
         **kwargs,
@@ -879,6 +882,7 @@ class DataPanel(
             batch_size=batch_size,
             num_workers=num_workers,
             input_columns=input_columns,
+            mmap=mmap,
             materialize=materialize,
             pbar=pbar,
         )

--- a/mosaic/mixins/cloneable.py
+++ b/mosaic/mixins/cloneable.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict
+
+
+class CloneableMixin:
+    def _clone_kwargs(self) -> Dict[str, Any]:
+        """Returns __init__ kwargs for instantiating new object.
+
+        This function returns the default parameters that should be plumbed
+        from the current instance to the new instance.
+
+        This is the API that should be used by DataPanel and AbstractColumn
+        subclasses that require unique protocols for instantiation.
+
+        Returns:
+            Dict[str, Any]: The keyword arguments for initialization.
+                These arguments will be used by :meth:`_clone`.
+        """
+        raise NotImplementedError()
+
+    def _clone(self, data=None, **kwargs):
+        default_kwargs = self._clone_kwargs()
+        if data is None:
+            data = kwargs.pop("data", self.data)
+        if kwargs:
+            default_kwargs.update(kwargs)
+        return self.__class__(data, **default_kwargs)


### PR DESCRIPTION
- [x] Plumb `mmap` to update
- [x] Refactor `from_data` for TensorColumn to remove need for unique implementations at subclass level
- [x] Remove `from_data` implementation in EmbeddingColumn (related to above)
- [x] Fix `mmap` implementation in column mapping
- [x] Add support for mapping complex columns (e.g. ClassificationOutputColumn) that cannot only be initialized with `data`.